### PR TITLE
chore: add libiconv for rust cookbook

### DIFF
--- a/docs/cookbook/languages/rust.md
+++ b/docs/cookbook/languages/rust.md
@@ -27,6 +27,8 @@ rustfmt.pkg-path = "rustfmt"
 rustfmt.pkg-group = "rust-toolchain"
 rust-lib-src.pkg-path = "rustPlatform.rustLibSrc"
 rust-lib-src.pkg-group = "rust-toolchain"
+libiconv.pkg-path = "libiconv"
+libiconv.systems = ["aarch64-darwin", "x86_64-darwin"]
 
 # rust-analyzer goes in its own group because it's updated
 # on a different cadence from the compiler and doesn't need


### PR DESCRIPTION
This is necessary on macOS and was just left out by mistake