### PR TITLE
Update docs for github actions

### DIFF
--- a/docs/tutorials/ci-cd.md
+++ b/docs/tutorials/ci-cd.md
@@ -34,10 +34,10 @@ jobs:
         uses: "actions/checkout@v4"
 
       - name: "Install Flox" # (2)!
-        uses: "flox/install-flox-action@2"
+        uses: "flox/install-flox-action@v2"
 
       - name: "Build" # (3)!
-        uses: "flox/activate-action@1"
+        uses: "flox/activate-action@v1"
         with:
           command: npm run build
 


### PR DESCRIPTION
Was getting flox set up in CI and noticed that the tags for the github actions are `v1` and `v2`.