### PR TITLE
doc(sharing): Remove containerize warning

### DIFF
--- a/docs/tutorials/sharing-environments.md
+++ b/docs/tutorials/sharing-environments.md
@@ -188,8 +188,6 @@ Now all new windows will open into your [FloxHub][floxhub_concept] environment. 
 
 Flox can render that environment as an OCI container runtime suitable for use with containerd, docker, kubernetes, nomad, and more.
 
-!!! warning "`flox containerize` is currently experimental and only supported on Linux"
-
 Let's create a container image from the `example-environment` we have been working with.
 
 To render your environment to a container, run `flox containerize`. This command

--- a/docs/tutorials/sharing-environments.md
+++ b/docs/tutorials/sharing-environments.md
@@ -216,7 +216,7 @@ Done.
 Now let's run a command from our image:
 
 ``` console
-$  docker run --rm -it flox-env-container -- telnet --version
+$  docker run --rm -it example-project -- telnet --version
 telnet (GNU inetutils) 2.5
 ...
 ```

--- a/docs/tutorials/sharing-environments.md
+++ b/docs/tutorials/sharing-environments.md
@@ -186,12 +186,12 @@ Now all new windows will open into your [FloxHub][floxhub_concept] environment. 
 
 ## Sharing with containers
 
-Flox can render that environment as an OCI container runtime suitable for use with containerd, docker, kubernetes, nomad, and more.
+Flox can render that environment as an OCI container runtime suitable for use with containerd, Docker, Kubernetes, Nomad, and more.
 
 Let's create a container image from the `example-environment` we have been working with.
 
 To render your environment to a container, run `flox containerize`. This command
-will pipe the container image to stdout for usage with `docker load`:
+will pipe the container image to STDOUT for usage with `docker load`:
 
 ``` { .console }
 $ flox containerize | docker load # (1)!
@@ -210,7 +210,7 @@ Done.
     command.
 
 !!! note "Why so many layers?"
-    By default flox splits every dependency into a different layers, which allows
+    By default Flox splits every dependency into a different layers, which allows
     better dependency sharing and faster iteration.
 
 Now let's run a command from our image:

--- a/docs/tutorials/sharing-environments.md
+++ b/docs/tutorials/sharing-environments.md
@@ -191,23 +191,18 @@ Flox can render that environment as an OCI container runtime suitable for use wi
 Let's create a container image from the `example-environment` we have been working with.
 
 To render your environment to a container, run `flox containerize`. This command
-will pipe the container image to STDOUT for usage with `docker load`:
+will automatically load the image into Docker:
 
 ``` { .console }
-$ flox containerize | docker load # (1)!
+$ flox containerize --runtime docker # (1)!
 ...
-Building container...
-Done.
-No 'fromImage' provided
 Creating layer 1 from paths: [...]
 ...
-Adding manifests...
-Done.
-✨  Container written to '/home/youruser/default-container.tar.gz'
+Loaded image: example-project:latest
+✨ Container written to Docker runtime
 ```
 
-1. `flox containerize` will stream generated docker image to `docker load`
-    command.
+1. See [`flox containerize`][flox_containerize] for more output options.
 
 !!! note "Why so many layers?"
     By default Flox splits every dependency into a different layers, which allows
@@ -233,3 +228,4 @@ telnet (GNU inetutils) 2.5
 [environment_concept]: ../concepts/environments.md
 [layering_guide]: ./layering-multiple-environments.md
 [customizing_guide]: ./customizing-environments.md
+[flox_containerize]: ../reference/command-reference/flox-containerize.md


### PR DESCRIPTION
⚠️ Don't merge before https://github.com/flox/flox/pull/2478 is released.

---

Now that we've:

1. Made it easier to use with `--tag` and `--runtime` support.
2. Added support for macOS.

Plus some other tidy ups while we're here.

- Old: https://flox.dev/docs/tutorials/sharing-environments/#sharing-with-containers
- New: https://5f6e9be35dee26908e207d99237f146d18f35992--floxdocs.netlify.app/docs/tutorials/sharing-environments/#sharing-with-containers