### PR TITLE
fix: recommend .zshrc and .zprofile for default env

### DIFF
--- a/docs/tutorials/default-environment.md
+++ b/docs/tutorials/default-environment.md
@@ -60,7 +60,8 @@ or you can add a single line to your shell's RC file:
 
 === "Zsh"
 
-    Add the following line to the very end of your `.zshenv` file:
+    Add the following line to the very end of your `.zprofile` and `.zshrc`
+    files:
 
     ```bash
     eval "$(flox activate -m run)"


### PR DESCRIPTION
Update docs to match https://github.com/flox/flox/pull/2505/

/usr/local/bin is not in path until path_helper runs which is run via /etc/profile, so flox won't be found.

We could recommend using the absolute path to flox, but path_helper will then put other paths in front of paths for the default environment.

Make the same recommendation on Linux for consistency. The default environment won't be activated for non-login non-interactive shells, but that behavior seems acceptable.