### PR TITLE
docs(nvm.md): Update nvm migration guide per feedback

### DIFF
--- a/check_links.sh
+++ b/check_links.sh
@@ -4,7 +4,9 @@ set -euo pipefail
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
+# Check links, excluding the bash manual and the docs for GNU Make (returns a 429)
 lychee $SCRIPT_DIR/site \
   -nv \
   --remap "https://flox.dev/docs file://$PWD/site" \
-  --exclude "bash/manual/html_node" # don't check the bash manual
+  --exclude "bash/manual/html_node" \
+  --exclude "https://www.gnu.org/software/make/"

--- a/docs/tutorials/migrations/nvm.md
+++ b/docs/tutorials/migrations/nvm.md
@@ -63,6 +63,18 @@ flox [node-project] ➜  node-project git:(main) ✗ node -v
 v20.18.1
 ```
 
+## Add Node.js and associated dependencies to a package group (optional)
+If you need an older version of node in your environment, we recommend that you specify a package group in your manifest to ensure that you can still install the latest versions of other software in your environment. (For more on the manifest and on package groups, read [our reference guide][manifest]{:target="\_blank"}.)
+
+You can run `flox edit` to open up the manifest for the environment.
+
+```toml
+...
+[install]
+nodejs_20 = { pkg-path = "nodejs_20", pkg-group = "node-toolchain" }
+...
+```
+
 ## Install other dependencies using Flox (optional)
 Assuming your project is like most Node.js applications, you probably have dependencies other than node to install. In this case, maybe you need PostgreSQL and nginx. Fortunately, you can install both using Flox, in the same way in which you installed node.
 
@@ -91,16 +103,14 @@ nodejs_22 - Event-driven I/O framework for the V8 JavaScript engine
 
 ```
 
-Once you know what's available, you can run `flox edit` to open up the manifest for the environment, as illustrated below. (For more on the manifest, read [our reference guide][manifest]{:target="\_blank"}.) You can set your desired node version directly in the manifest, and then save your changes.
+Once you know what's available, you can run `flox edit` to open up the manifest for the environment. You can then set your desired node version directly in the manifest, and then save your changes. Note that you'll need to prepend `nodejs-` to whatever Node.js version number you intend to set in the manifest. This is required because of how those versions are stored in the Nix Packages collection.
 
-Note that you'll need to prepend `nodejs-` to whatever Node.js version number you intend set in the manifest. This is required because of how those versions are stored in the Nix Packages collection.
+(If you omit the specific version, you will get the latest version of `nodejs_22` that's compatible with everything in your environment. If you have a `pkg-group` set but no specific `version`, you'll get the latest version that's compatible with the rest of the software in the package group.)
 
 ```toml
 ...
-# List packages you wish to install in your environment inside
-# the `[install]` section.
 [install]
-nodejs_22 = { pkg-path = "nodejs_22", version = "nodejs-22.10.0" }
+nodejs_22 = { pkg-path = "nodejs_22", pkg-group = "node-toolchain", version = "nodejs-22.10.0" }
 ...
 ```
 

--- a/docs/tutorials/migrations/nvm.md
+++ b/docs/tutorials/migrations/nvm.md
@@ -14,15 +14,16 @@ nvm does exactly what it purports to do: it manages Node.js versions simply and 
 
 * **You work on a team with members who have diverse skill sets, and you want to have a single entrypoint for development, regardless of language ecosystem.** No matter what languages and technologies your team is comfortable with, they can use the same Flox commands to spin up their local dev environments. For example, instead of asking a Java developer who uses a Linux machine to install nvm in order to get the right node version for your project, you can offer a better solution. That developer can use the same Flox commands they use to activate their own projects to activate the dev environment for your node project, which you develop on your Mac.
 * **You want a tool that allows you to manage Node.js versions as well as other dependencies.** Having a single-use tool like nvm is fine, but what if you could install node, PostgreSQL, nginx, etc. with a single command? Flox lets you do just that. It also [allows you to configure and run services][services]{:target="\_blank"}, the latter of which you can do simply by adding the `--start-services` argument to `flox activate`.
+* **You need to use [`node-gyp`](https://github.com/nodejs/node-gyp){:target="\_blank"} to compile native add-on modules for Node.js, and you want to be sure you have the right version of Python, [Make](https://www.gnu.org/software/make/){:target="\_blank"}, [GCC](https://gcc.gnu.org/){:target="\_blank"}, [Clang](https://clang.llvm.org/get_started.html), and other dependencies.** As a Flox user, you can be certain you'll install versions of these dependencies that are compatible with the node version in your environment. This is all thanks to Nix Packages, which is the underlying software repository on which the Flox Catalog is based.
 * **You need to manage versions of other JavaScript runtimes, like Bun or Deno.** While nvm is, as the name denotes, used for managing Node.js versions, that's all it does. You can use Flox to install node, but you can also use it to install different JavaScript runtimes, including [Bun](https://bun.sh/){:target="\_blank"} and [Deno](https://deno.com/){:target="\_blank"}.
 
 ## Install Flox
 Download and install Flox as described in our [installation instructions][install_flox]{:target="\_blank"}.
 
 ## Create a Flox environment in your existing project and install Node.js
-Navigate to your project's directory and run `flox init`, and then search for the version of Node.js that is currently included in your `.nvmrc`, or in the `"engines"` property of your `package.json`. (Note that node is listed as `nodejs` and variants thereof in the Flox catalog.)
+Navigate to your project's directory and run `flox init`, and then search for the version of Node.js that is currently included in your `.nvmrc`, or in the `"engines"` property of your `package.json`. (Note that node is listed as `nodejs` and variants thereof in the Flox Catalog.)
 
-```zsh
+```console
 ➜  node-project git:(main) ✗ flox search nodejs
 nodejs       Event-driven I/O framework for the V8 JavaScript engine
 nodejs_14    Event-driven I/O framework for the V8 JavaScript engine
@@ -40,9 +41,11 @@ Showing 10 of 67 results. Use `flox search nodejs --all` to see the full list.
 Use 'flox show <package>' to see available versions
 ```
 
-There is _a lot_ of software in the Flox Catalog, so you should have no trouble finding the node version you need. For this project, perhaps you decide to install Node.js v20.18.1.
+There is _a lot_ of software in the Flox Catalog, so you should have no trouble finding the node version you need. We recommend that you install one of the `nodejs` packages with a numerical suffix (e.g., `nodejs_18` or `nodejs_22`), rather than `nodejs`, which is the latest stable version of node from the perspective of the Nix Packages maintainers. The `nodejs` package may not get a new version until all the other Nix packages that depend on that specific Node.js version have been updated for compatibility, which could be a long while after an official Node.js release.
 
-```zsh
+At any rate, for this project, perhaps you decide to install Node.js v20.18.1.
+
+```console
 ➜  node-project git:(main) ✗ flox install nodejs_20
 ✅ 'nodejs_20' installed to environment 'node-project'
 ```
@@ -50,7 +53,7 @@ There is _a lot_ of software in the Flox Catalog, so you should have no trouble 
 ## Verify the Node.js version
 Now that you've installed node, you activate the Flox environment to verify that it has the the version you expect.
 
-```zsh
+```console
 ➜  node-project git:(main) ✗ flox activate
 ✅ You are now using the environment 'node-project'.
 To stop using this environment, type 'exit'
@@ -63,7 +66,7 @@ v20.18.1
 ## Install other dependencies using Flox (optional)
 Assuming your project is like most Node.js applications, you probably have dependencies other than node to install. In this case, maybe you need PostgreSQL and nginx. Fortunately, you can install both using Flox, in the same way in which you installed node.
 
-```zsh
+```console
 flox [node-project] ➜  node-project git:(main) ✗ flox install postgresql nginx
 ✅ 'postgresql' installed to environment 'node-project'
 ✅ 'nginx' installed to environment 'node-project'
@@ -71,9 +74,9 @@ flox [node-project] ➜  node-project git:(main) ✗ flox install postgresql ngi
 Now you have everything you need to develop locally, and you didn't have to figure out how to install [nginx](https://nginx.org/en/docs/install.html){:target="\_blank"} and [PostgreSQL](https://www.postgresql.org/download/){:target="\_blank"} individually.
 
 ## Update the Node.js version
-If you want to install a different node version, you can always update your environment to include the version you need. For example, let's say you're upgrading your project to Node.js v22. The best way to get the correct Flox catalog version name for your desired version is to run `flox show <package>`:
+If you want to install a different node version, you can always update your environment to include the version you need. For example, let's say you're upgrading your project to Node.js v22. The best way to get the correct Flox Catalog version name for your desired version is to run `flox show <package>`:
 
-```zsh
+```console
 flox [node-project] ➜  node-project git:(main) ✗ flox show nodejs_22
 nodejs_22 - Event-driven I/O framework for the V8 JavaScript engine
     nodejs_22@nodejs-22.10.0


### PR DESCRIPTION
### Notes for reviewers

- Added a section on `node-gyp`, because this is definitely an area where Flox will shine in comparison with nvm (thanks, @stahnma)
- Added an optional section about using a `pkg-group`, which I'm recommending in cases where the Node.js version to install is on the older side
- Added some clarification about the `nodejs` package versus those that have numerical suffixes