### PR TITLE
docs(nvm.md): Improve utility of Flox command snippets

### DIFF
--- a/docs/tutorials/migrations/nvm.md
+++ b/docs/tutorials/migrations/nvm.md
@@ -21,7 +21,19 @@ nvm does exactly what it purports to do: it manages Node.js versions simply and 
 Download and install Flox as described in our [installation instructions][install_flox]{:target="\_blank"}.
 
 ## Create a Flox environment in your existing project and install Node.js
-Navigate to your project's directory and run `flox init`, and then search for the version of Node.js that is currently included in your `.nvmrc`, or in the `"engines"` property of your `package.json`. (Note that node is listed as `nodejs` and variants thereof in the Flox Catalog.)
+Navigate to your project's directory and run this command to initialize a Flox environment:
+
+```sh
+flox init
+```
+
+After that's done, you can search for the version of Node.js that is currently included in your `.nvmrc`, or in the `"engines"` property of your `package.json`. (Note that node is listed as `nodejs` and variants thereof in the Flox Catalog.)
+
+```sh
+flox search nodejs
+```
+
+When you search for Node.js, you'll see output like this in your terminal:
 
 ```console
 ➜  node-project git:(main) ✗ flox search nodejs
@@ -43,7 +55,13 @@ Use 'flox show <package>' to see available versions
 
 There is _a lot_ of software in the Flox Catalog, so you should have no trouble finding the node version you need. We recommend that you install one of the `nodejs` packages with a numerical suffix (e.g., `nodejs_18` or `nodejs_22`), rather than `nodejs`, which is the latest stable version of node from the perspective of the Nix Packages maintainers. The `nodejs` package may not get a new version until all the other Nix packages that depend on that specific Node.js version have been updated for compatibility, which could be a long while after an official Node.js release.
 
-At any rate, for this project, perhaps you decide to install Node.js v20.18.1.
+At any rate, for this project, perhaps you decide to install Node.js v20.18.1. You can start by running the following command:
+
+```sh
+flox install nodejs_20
+```
+
+This should yield the following output:
 
 ```console
 ➜  node-project git:(main) ✗ flox install nodejs_20
@@ -53,12 +71,27 @@ At any rate, for this project, perhaps you decide to install Node.js v20.18.1.
 ## Verify the Node.js version
 Now that you've installed node, you activate the Flox environment to verify that it has the the version you expect.
 
+```sh
+flox activate
+```
+
+When you activate the environment, you'll see output like this in your terminal:
+
 ```console
 ➜  node-project git:(main) ✗ flox activate
 ✅ You are now using the environment 'node-project'.
 To stop using this environment, type 'exit'
+```
 
-...
+Within the active Flox environment, you can verify the node version as follows:
+
+```sh
+node -v
+```
+
+This command should give you the output you expect, namely the version of node available in your shell:
+
+```console
 flox [node-project] ➜  node-project git:(main) ✗ node -v
 v20.18.1
 ```
@@ -66,7 +99,13 @@ v20.18.1
 ## Add Node.js and associated dependencies to a package group (optional)
 If you need an older version of node in your environment, we recommend that you specify a package group in your manifest to ensure that you can still install the latest versions of other software in your environment. (For more on the manifest and on package groups, read [our reference guide][manifest]{:target="\_blank"}.)
 
-You can run `flox edit` to open up the manifest for the environment.
+At this point, you should run the following command to edit the Flox environment configuration manually:
+
+```sh
+flox edit
+```
+
+Now you can edit the `manifest.toml` as illustrated below.
 
 ```toml
 ...
@@ -78,6 +117,12 @@ nodejs_20 = { pkg-path = "nodejs_20", pkg-group = "node-toolchain" }
 ## Install other dependencies using Flox (optional)
 Assuming your project is like most Node.js applications, you probably have dependencies other than node to install. In this case, maybe you need PostgreSQL and nginx. Fortunately, you can install both using Flox, in the same way in which you installed node.
 
+```sh
+flox install postgresql nginx
+```
+
+Running this command will install both dependencies to the Flox environment.
+
 ```console
 flox [node-project] ➜  node-project git:(main) ✗ flox install postgresql nginx
 ✅ 'postgresql' installed to environment 'node-project'
@@ -87,6 +132,12 @@ Now you have everything you need to develop locally, and you didn't have to figu
 
 ## Update the Node.js version
 If you want to install a different node version, you can always update your environment to include the version you need. For example, let's say you're upgrading your project to Node.js v22. The best way to get the correct Flox Catalog version name for your desired version is to run `flox show <package>`:
+
+```sh
+flox show nodejs_22
+```
+
+Now you can see all the available versions of Node.js v22 in the Flox Catalog.
 
 ```console
 flox [node-project] ➜  node-project git:(main) ✗ flox show nodejs_22
@@ -103,7 +154,13 @@ nodejs_22 - Event-driven I/O framework for the V8 JavaScript engine
 
 ```
 
-Once you know what's available, you can run `flox edit` to open up the manifest for the environment. You can then set your desired node version directly in the manifest, and then save your changes. Note that you'll need to prepend `nodejs-` to whatever Node.js version number you intend to set in the manifest. This is required because of how those versions are stored in the Nix Packages collection.
+Once you know what's available, you can run the edit command to open up the manifest for the environment:
+
+```sh
+flox edit
+```
+
+You can now set your desired node version directly in the manifest, and then save your changes. Note that you'll need to prepend `nodejs-` to whatever Node.js version number you intend to set in the manifest. This is required because of how those versions are stored in the Nix Packages collection.
 
 (If you omit the specific version, you will get the latest version of `nodejs_22` that's compatible with everything in your environment. If you have a `pkg-group` set but no specific `version`, you'll get the latest version that's compatible with the rest of the software in the package group.)
 


### PR DESCRIPTION
I solicited feedback from a former colleague, who made the very helpful suggestion that each command that the user is meant to run should be rendered in its own snippet that can be copied by clicking on the copy to clipboard button. This makes the guide more user friendly and prevents any issues that might arise when the reader misses a command that's embedded in a block of text.