### PR TITLE
Fix linting

### DIFF
--- a/.flox/env/manifest.lock
+++ b/.flox/env/manifest.lock
@@ -19,10 +19,12 @@
         "pkg-path": "gnutar"
       },
       "lychee": {
-        "pkg-path": "lychee"
+        "pkg-path": "lychee",
+        "pkg-group": "lint"
       },
       "markdownlint-cli2": {
-        "pkg-path": "markdownlint-cli2"
+        "pkg-path": "markdownlint-cli2",
+        "pkg-group": "lint"
       },
       "pandoc": {
         "pkg-path": "pandoc"
@@ -695,246 +697,6 @@
       "priority": 5
     },
     {
-      "attr_path": "lychee",
-      "broken": false,
-      "derivation": "/nix/store/iwnxlyb7kgyah9w1ama9y12b1xs6s1nz-lychee-0.15.1.drv",
-      "description": "Fast, async, stream-based link checker written in Rust",
-      "install_id": "lychee",
-      "license": "[ Apache-2.0, MIT ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=9f4128e00b0ae8ec65918efeba59db998750ead6",
-      "name": "lychee-0.15.1",
-      "pname": "lychee",
-      "rev": "9f4128e00b0ae8ec65918efeba59db998750ead6",
-      "rev_count": 647193,
-      "rev_date": "2024-07-03T18:27:49Z",
-      "scrape_date": "2024-07-05T00:14:29Z",
-      "stabilities": [
-        "staging",
-        "unstable"
-      ],
-      "unfree": false,
-      "version": "0.15.1",
-      "outputs_to_install": [
-        "out"
-      ],
-      "outputs": {
-        "out": "/nix/store/gs0b4f8bms0gr30n4ba9bjlpj3zhd9a1-lychee-0.15.1"
-      },
-      "system": "aarch64-darwin",
-      "group": "toplevel",
-      "priority": 5
-    },
-    {
-      "attr_path": "lychee",
-      "broken": false,
-      "derivation": "/nix/store/p91bd930psw666kchxqpkm6v0nla431g-lychee-0.15.1.drv",
-      "description": "Fast, async, stream-based link checker written in Rust",
-      "install_id": "lychee",
-      "license": "[ Apache-2.0, MIT ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=9f4128e00b0ae8ec65918efeba59db998750ead6",
-      "name": "lychee-0.15.1",
-      "pname": "lychee",
-      "rev": "9f4128e00b0ae8ec65918efeba59db998750ead6",
-      "rev_count": 647193,
-      "rev_date": "2024-07-03T18:27:49Z",
-      "scrape_date": "2024-07-05T00:14:29Z",
-      "stabilities": [
-        "staging",
-        "unstable"
-      ],
-      "unfree": false,
-      "version": "0.15.1",
-      "outputs_to_install": [
-        "out"
-      ],
-      "outputs": {
-        "out": "/nix/store/c027wvw59f7fsx98gi46j9myzh80m83n-lychee-0.15.1"
-      },
-      "system": "aarch64-linux",
-      "group": "toplevel",
-      "priority": 5
-    },
-    {
-      "attr_path": "lychee",
-      "broken": false,
-      "derivation": "/nix/store/j9l5vgw3zi5i8s8yj7rb2dbd9h1875m6-lychee-0.15.1.drv",
-      "description": "Fast, async, stream-based link checker written in Rust",
-      "install_id": "lychee",
-      "license": "[ Apache-2.0, MIT ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=9f4128e00b0ae8ec65918efeba59db998750ead6",
-      "name": "lychee-0.15.1",
-      "pname": "lychee",
-      "rev": "9f4128e00b0ae8ec65918efeba59db998750ead6",
-      "rev_count": 647193,
-      "rev_date": "2024-07-03T18:27:49Z",
-      "scrape_date": "2024-07-05T00:14:29Z",
-      "stabilities": [
-        "staging",
-        "unstable"
-      ],
-      "unfree": false,
-      "version": "0.15.1",
-      "outputs_to_install": [
-        "out"
-      ],
-      "outputs": {
-        "out": "/nix/store/4h1x38h1v075599k9wvjvzj0wa32fkz5-lychee-0.15.1"
-      },
-      "system": "x86_64-darwin",
-      "group": "toplevel",
-      "priority": 5
-    },
-    {
-      "attr_path": "lychee",
-      "broken": false,
-      "derivation": "/nix/store/2mw8jd8a0d9x7vn6hpv9c7rnvqbxvdc2-lychee-0.15.1.drv",
-      "description": "Fast, async, stream-based link checker written in Rust",
-      "install_id": "lychee",
-      "license": "[ Apache-2.0, MIT ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=9f4128e00b0ae8ec65918efeba59db998750ead6",
-      "name": "lychee-0.15.1",
-      "pname": "lychee",
-      "rev": "9f4128e00b0ae8ec65918efeba59db998750ead6",
-      "rev_count": 647193,
-      "rev_date": "2024-07-03T18:27:49Z",
-      "scrape_date": "2024-07-05T00:14:29Z",
-      "stabilities": [
-        "staging",
-        "unstable"
-      ],
-      "unfree": false,
-      "version": "0.15.1",
-      "outputs_to_install": [
-        "out"
-      ],
-      "outputs": {
-        "out": "/nix/store/rvrz40d17n04dxapsrhrpwis3bbfs1nx-lychee-0.15.1"
-      },
-      "system": "x86_64-linux",
-      "group": "toplevel",
-      "priority": 5
-    },
-    {
-      "attr_path": "markdownlint-cli2",
-      "broken": false,
-      "derivation": "/nix/store/ly73723him9mxrq1c51ac69x3bapj3a6-markdownlint-cli2-0.9.0.drv",
-      "description": "Fast, flexible, configuration-based command-line interface for linting Markdown/CommonMark files with the markdownlint library",
-      "install_id": "markdownlint-cli2",
-      "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=9f4128e00b0ae8ec65918efeba59db998750ead6",
-      "name": "markdownlint-cli2-0.9.0",
-      "pname": "markdownlint-cli2",
-      "rev": "9f4128e00b0ae8ec65918efeba59db998750ead6",
-      "rev_count": 647193,
-      "rev_date": "2024-07-03T18:27:49Z",
-      "scrape_date": "2024-07-05T00:14:29Z",
-      "stabilities": [
-        "staging",
-        "unstable"
-      ],
-      "unfree": false,
-      "version": "0.9.0",
-      "outputs_to_install": [
-        "out"
-      ],
-      "outputs": {
-        "out": "/nix/store/gq9z5kgjvy0fkb6z34798ixzmr95vzg4-markdownlint-cli2-0.9.0"
-      },
-      "system": "aarch64-darwin",
-      "group": "toplevel",
-      "priority": 5
-    },
-    {
-      "attr_path": "markdownlint-cli2",
-      "broken": false,
-      "derivation": "/nix/store/s0py830wfl7h1h0fl6d4gjcycdgfyf88-markdownlint-cli2-0.9.0.drv",
-      "description": "Fast, flexible, configuration-based command-line interface for linting Markdown/CommonMark files with the markdownlint library",
-      "install_id": "markdownlint-cli2",
-      "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=9f4128e00b0ae8ec65918efeba59db998750ead6",
-      "name": "markdownlint-cli2-0.9.0",
-      "pname": "markdownlint-cli2",
-      "rev": "9f4128e00b0ae8ec65918efeba59db998750ead6",
-      "rev_count": 647193,
-      "rev_date": "2024-07-03T18:27:49Z",
-      "scrape_date": "2024-07-05T00:14:29Z",
-      "stabilities": [
-        "staging",
-        "unstable"
-      ],
-      "unfree": false,
-      "version": "0.9.0",
-      "outputs_to_install": [
-        "out"
-      ],
-      "outputs": {
-        "out": "/nix/store/3vjb5jnyn7jpcfvmkv2cv4w2api4wn20-markdownlint-cli2-0.9.0"
-      },
-      "system": "aarch64-linux",
-      "group": "toplevel",
-      "priority": 5
-    },
-    {
-      "attr_path": "markdownlint-cli2",
-      "broken": false,
-      "derivation": "/nix/store/siqhdbkdlj22zv4bsb78cnzmvch1m4lb-markdownlint-cli2-0.9.0.drv",
-      "description": "Fast, flexible, configuration-based command-line interface for linting Markdown/CommonMark files with the markdownlint library",
-      "install_id": "markdownlint-cli2",
-      "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=9f4128e00b0ae8ec65918efeba59db998750ead6",
-      "name": "markdownlint-cli2-0.9.0",
-      "pname": "markdownlint-cli2",
-      "rev": "9f4128e00b0ae8ec65918efeba59db998750ead6",
-      "rev_count": 647193,
-      "rev_date": "2024-07-03T18:27:49Z",
-      "scrape_date": "2024-07-05T00:14:29Z",
-      "stabilities": [
-        "staging",
-        "unstable"
-      ],
-      "unfree": false,
-      "version": "0.9.0",
-      "outputs_to_install": [
-        "out"
-      ],
-      "outputs": {
-        "out": "/nix/store/6aiky5csv516s8iga664kpaa7q7wh6p9-markdownlint-cli2-0.9.0"
-      },
-      "system": "x86_64-darwin",
-      "group": "toplevel",
-      "priority": 5
-    },
-    {
-      "attr_path": "markdownlint-cli2",
-      "broken": false,
-      "derivation": "/nix/store/lid3nxlgcxf7rh63i44pj4avh4ffnabj-markdownlint-cli2-0.9.0.drv",
-      "description": "Fast, flexible, configuration-based command-line interface for linting Markdown/CommonMark files with the markdownlint library",
-      "install_id": "markdownlint-cli2",
-      "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=9f4128e00b0ae8ec65918efeba59db998750ead6",
-      "name": "markdownlint-cli2-0.9.0",
-      "pname": "markdownlint-cli2",
-      "rev": "9f4128e00b0ae8ec65918efeba59db998750ead6",
-      "rev_count": 647193,
-      "rev_date": "2024-07-03T18:27:49Z",
-      "scrape_date": "2024-07-05T00:14:29Z",
-      "stabilities": [
-        "staging",
-        "unstable"
-      ],
-      "unfree": false,
-      "version": "0.9.0",
-      "outputs_to_install": [
-        "out"
-      ],
-      "outputs": {
-        "out": "/nix/store/12q9lc86ac5i78crmxa0kzq3xc6wsg8k-markdownlint-cli2-0.9.0"
-      },
-      "system": "x86_64-linux",
-      "group": "toplevel",
-      "priority": 5
-    },
-    {
       "attr_path": "pandoc",
       "broken": false,
       "derivation": "/nix/store/wm2kcq4fhy0xpgwy8s3rcn22fjwfw9fa-pandoc-cli-3.1.11.1.drv",
@@ -1426,6 +1188,238 @@
       },
       "system": "x86_64-linux",
       "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "lychee",
+      "broken": false,
+      "derivation": "/nix/store/b2lcd7yfgjik2yyg7mzhj2lr06xk6cyj-lychee-0.18.0.drv",
+      "description": "Fast, async, stream-based link checker written in Rust",
+      "install_id": "lychee",
+      "license": "[ Apache-2.0, MIT ]",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=9d3ae807ebd2981d593cddd0080856873139aa40",
+      "name": "lychee-0.18.0",
+      "pname": "lychee",
+      "rev": "9d3ae807ebd2981d593cddd0080856873139aa40",
+      "rev_count": 745286,
+      "rev_date": "2025-01-29T09:16:47Z",
+      "scrape_date": "2025-01-30T03:28:02Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.18.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/rjwp9rqf7fzh5z1dpn3nsn6hh3mk38z5-lychee-0.18.0"
+      },
+      "system": "aarch64-darwin",
+      "group": "lint",
+      "priority": 5
+    },
+    {
+      "attr_path": "lychee",
+      "broken": false,
+      "derivation": "/nix/store/4lilr0dpihhdkdds447y9a84gkm4lb8m-lychee-0.18.0.drv",
+      "description": "Fast, async, stream-based link checker written in Rust",
+      "install_id": "lychee",
+      "license": "[ Apache-2.0, MIT ]",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=9d3ae807ebd2981d593cddd0080856873139aa40",
+      "name": "lychee-0.18.0",
+      "pname": "lychee",
+      "rev": "9d3ae807ebd2981d593cddd0080856873139aa40",
+      "rev_count": 745286,
+      "rev_date": "2025-01-29T09:16:47Z",
+      "scrape_date": "2025-01-30T03:28:02Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.18.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/8470k69c3y4f4cxnxc09i1phfifprszy-lychee-0.18.0"
+      },
+      "system": "aarch64-linux",
+      "group": "lint",
+      "priority": 5
+    },
+    {
+      "attr_path": "lychee",
+      "broken": false,
+      "derivation": "/nix/store/r76gm0mb0517005bba5rw0arm7f92mi0-lychee-0.18.0.drv",
+      "description": "Fast, async, stream-based link checker written in Rust",
+      "install_id": "lychee",
+      "license": "[ Apache-2.0, MIT ]",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=9d3ae807ebd2981d593cddd0080856873139aa40",
+      "name": "lychee-0.18.0",
+      "pname": "lychee",
+      "rev": "9d3ae807ebd2981d593cddd0080856873139aa40",
+      "rev_count": 745286,
+      "rev_date": "2025-01-29T09:16:47Z",
+      "scrape_date": "2025-01-30T03:28:02Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.18.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/n8haxvy0bdxzmx813dg1p7xv0qjc9lg4-lychee-0.18.0"
+      },
+      "system": "x86_64-darwin",
+      "group": "lint",
+      "priority": 5
+    },
+    {
+      "attr_path": "lychee",
+      "broken": false,
+      "derivation": "/nix/store/65c73xnad8bnp4lckpxsqpirgxzrkdan-lychee-0.18.0.drv",
+      "description": "Fast, async, stream-based link checker written in Rust",
+      "install_id": "lychee",
+      "license": "[ Apache-2.0, MIT ]",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=9d3ae807ebd2981d593cddd0080856873139aa40",
+      "name": "lychee-0.18.0",
+      "pname": "lychee",
+      "rev": "9d3ae807ebd2981d593cddd0080856873139aa40",
+      "rev_count": 745286,
+      "rev_date": "2025-01-29T09:16:47Z",
+      "scrape_date": "2025-01-30T03:28:02Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.18.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/dn02smsl6qn3ra57bx3q9zki4cb1d13b-lychee-0.18.0"
+      },
+      "system": "x86_64-linux",
+      "group": "lint",
+      "priority": 5
+    },
+    {
+      "attr_path": "markdownlint-cli2",
+      "broken": false,
+      "derivation": "/nix/store/jrl4pjhvq0ykrw1gdgqlcj2jav4ch8dw-markdownlint-cli2-0.17.1.drv",
+      "description": "Fast, flexible, configuration-based command-line interface for linting Markdown/CommonMark files with the markdownlint library",
+      "install_id": "markdownlint-cli2",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=9d3ae807ebd2981d593cddd0080856873139aa40",
+      "name": "markdownlint-cli2-0.17.1",
+      "pname": "markdownlint-cli2",
+      "rev": "9d3ae807ebd2981d593cddd0080856873139aa40",
+      "rev_count": 745286,
+      "rev_date": "2025-01-29T09:16:47Z",
+      "scrape_date": "2025-01-30T03:28:02Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.17.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/0in7cysb8hgmdk1v0v9s8a162xlr7pbv-markdownlint-cli2-0.17.1"
+      },
+      "system": "aarch64-darwin",
+      "group": "lint",
+      "priority": 5
+    },
+    {
+      "attr_path": "markdownlint-cli2",
+      "broken": false,
+      "derivation": "/nix/store/mv4zdv2bk3x8jgs4y31lvpbfczn6gh84-markdownlint-cli2-0.17.1.drv",
+      "description": "Fast, flexible, configuration-based command-line interface for linting Markdown/CommonMark files with the markdownlint library",
+      "install_id": "markdownlint-cli2",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=9d3ae807ebd2981d593cddd0080856873139aa40",
+      "name": "markdownlint-cli2-0.17.1",
+      "pname": "markdownlint-cli2",
+      "rev": "9d3ae807ebd2981d593cddd0080856873139aa40",
+      "rev_count": 745286,
+      "rev_date": "2025-01-29T09:16:47Z",
+      "scrape_date": "2025-01-30T03:28:02Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.17.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/sf3d3c51y7qli9jq9gzbyp2v6bjsj1jd-markdownlint-cli2-0.17.1"
+      },
+      "system": "aarch64-linux",
+      "group": "lint",
+      "priority": 5
+    },
+    {
+      "attr_path": "markdownlint-cli2",
+      "broken": false,
+      "derivation": "/nix/store/3g0h3k299pjfnzs963v43g85nqscnyr0-markdownlint-cli2-0.17.1.drv",
+      "description": "Fast, flexible, configuration-based command-line interface for linting Markdown/CommonMark files with the markdownlint library",
+      "install_id": "markdownlint-cli2",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=9d3ae807ebd2981d593cddd0080856873139aa40",
+      "name": "markdownlint-cli2-0.17.1",
+      "pname": "markdownlint-cli2",
+      "rev": "9d3ae807ebd2981d593cddd0080856873139aa40",
+      "rev_count": 745286,
+      "rev_date": "2025-01-29T09:16:47Z",
+      "scrape_date": "2025-01-30T03:28:02Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.17.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/6ygc1dd22x94idxbd0x2z9ajs7jp8rn0-markdownlint-cli2-0.17.1"
+      },
+      "system": "x86_64-darwin",
+      "group": "lint",
+      "priority": 5
+    },
+    {
+      "attr_path": "markdownlint-cli2",
+      "broken": false,
+      "derivation": "/nix/store/3mskh8hrl595nxva70pw3ibnprp4zsg9-markdownlint-cli2-0.17.1.drv",
+      "description": "Fast, flexible, configuration-based command-line interface for linting Markdown/CommonMark files with the markdownlint library",
+      "install_id": "markdownlint-cli2",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=9d3ae807ebd2981d593cddd0080856873139aa40",
+      "name": "markdownlint-cli2-0.17.1",
+      "pname": "markdownlint-cli2",
+      "rev": "9d3ae807ebd2981d593cddd0080856873139aa40",
+      "rev_count": 745286,
+      "rev_date": "2025-01-29T09:16:47Z",
+      "scrape_date": "2025-01-30T03:28:02Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.17.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/jjxcgyvbxgf5vdapfqipqnc1j7jj16gs-markdownlint-cli2-0.17.1"
+      },
+      "system": "x86_64-linux",
+      "group": "lint",
       "priority": 5
     }
   ]

--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -11,7 +11,6 @@ version = 1
 coreutils.pkg-path = "coreutils"
 findutils.pkg-path = "findutils"
 gnutar.pkg-path = "gnutar"
-lychee.pkg-path = "lychee"
 pandoc.pkg-path = "pandoc"
 poetry.pkg-path = "poetry"
 python.pkg-path = "python3"
@@ -19,7 +18,11 @@ python.version = "3.11.*"
 pngquant.pkg-path = "pngquant"
 gnused.pkg-path = "gnused"
 d2.pkg-path = "d2"
+
+lychee.pkg-path = "lychee"
+lychee.pkg-group = "lint"
 markdownlint-cli2.pkg-path = "markdownlint-cli2"
+markdownlint-cli2.pkg-group = "lint"
 
 # Set environment variables in the `[vars]` section. These variables may not
 # reference one another, and are added to the environment without first

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - name: "Check markdown lint"
         uses: "flox/activate-action@main"
         with:
-          command: "markdownlint-cli2 docs/**/*.md"
+          command: "markdownlint-cli2"
 
       - name: "Check external links"
         uses: "flox/activate-action@main"

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,5 +1,6 @@
 globs:
   - "docs/**/*.md"
+gitignore: true
 
 config:
   # Not worth worrying about.

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,3 +1,6 @@
+globs:
+  - "docs/**/*.md"
+
 config:
   # Not worth worrying about.
   code-block-style: false

--- a/docs/tutorials/migrations/homebrew.md
+++ b/docs/tutorials/migrations/homebrew.md
@@ -12,6 +12,7 @@ Flox can replace [Homebrew](https://brew.sh) entirely, or they can be used toget
 This guide explains how to introduce Flox into environments where Homebrew is currently being used, either as a replacement or an addition. It introduces new concepts and proposes a basic procedure for mapping packages.
 
 ## Why you might want to migrate
+
 Homebrew does a great job, and has been loved as the “missing package manager” for a generation of macOS users. But there are a few reasons you might consider moving to Flox:
 
 * **You need a cross-platform package manager.** Flox works on both macOS and Linux - x86 and ARM - allowing you to define a set of packages that works the same everywhere.
@@ -21,9 +22,11 @@ Homebrew does a great job, and has been loved as the “missing package manager�
 * **You need older versions of software.** The Flox Catalog contains historical versions of each of its packages, and makes it easy to install them.
 
 ## Install Flox
+
 Download and install Flox following the [installation instructions][install_flox].
 
 ## Migrate your first package
+
 Migrating to Flox is a straightforward process of installing Flox packages for each of your Homebrew formulae. This section walks you through the process for identifying the set of Homebrew formulae you currently have installed, searching for the corresponding packages in the Flox Catalog, and installing them.
 
 As a Homebrew user, you will find several of the Flox subcommands familiar:
@@ -33,6 +36,7 @@ As a Homebrew user, you will find several of the Flox subcommands familiar:
 * [`uninstall`][uninstall] is used to remove packages
 
 ### Show top-level formulae in Homebrew
+
 First, identify the list of Homebrew packages you have installed.
 
 We recommend using `brew leaves` for this, so you can easily differentiate between the formulae you installed explicitly versus those that were installed as dependencies. The `leaves` subcommand will show the formulae that were directly installed.
@@ -63,6 +67,7 @@ wget
 ```
 
 ### Search for a package in Flox
+
 Then, search Flox for one of the formulae you have installed with Homebrew. In this case, for example, you could choose `jq`:
 
 ```
@@ -86,13 +91,14 @@ Use 'flox show <package>' to see available versions
 The first one on the list is the correct Flox package to install, and it has the same name as the Homebrew package. This will often be the case, but not always.
 
 ### Install your first package
+
 To install your first package, use `flox install`:
 
 ```
 % flox install jq
 ```
 
-The first time you install a package, Flox will ask you whether you want to create a [default environment][default_tutorial]. 
+The first time you install a package, Flox will ask you whether you want to create a [default environment][default_tutorial].
 
 ```
 % flox install jq
@@ -133,6 +139,7 @@ Creating a Flox default environment is optional.
 If you do not choose for this to be automated at the time of your first package installation, you can [follow these instructions][default_tutorial_setup] to add Flox to your dotfiles manually.
 
 ### Verify configuration
+
 Exit your active shell and create a new one, causing the dotfile changes to take effect. The first time this happens, you may experience a delay while your default environment is materialized. The next time you open a shell it should be quick because the environment has been cached.
 
 Once the shell is available, you can verify that your default environment is active by running [`flox envs`][envs]:
@@ -153,6 +160,7 @@ jq: jq (1.7.1)
 ```
 
 ## Create environments for projects
+
 As you continue to migrate packages from Homebrew to Flox, you may find that you don’t need them all in your default environment.
 
 The default environment is intended for packages that should be available to the user across all of the contexts where they work. It is commonly used for general utilities like `gh`, `gnused`, and `curl` that apply to many situations.
@@ -172,20 +180,22 @@ When installing packages that you are accustomed to getting from Homebrew, consi
 * install the rest into environments for the projects or contexts where they are required.
 
 ## Complete the migration
+
 Once you have installed all of the Flox packages you need, you have a few options. You can either uninstall Homebrew and use Flox exclusively, or you can use them together.
 
 ### Option 1: Uninstall Homebrew
+
 If Flox has everything you need and is working satisfactorally, you may no longer need Homebrew. In this case, it’s a good idea to uninstall it so it doesn’t affect your system in potentially confusing ways.
 
 To do this, follow [the instructions in the Homebrew FAQ](https://docs.brew.sh/FAQ#how-do-i-uninstall-homebrew).
 
 ### Option 2: Use Flox and Homebrew together
+
 Homebrew and Flox can be used together, and there is no need to uninstall Homebrew in order to use Flox.
 
 However, if you have the Flox default environment enabled, you should be aware of the order of Homebrew and Flox entries in your dotfiles. Both Homebrew and Flox modify your `PATH`, and the one that appears later in your dotfiles will take precedence. If the same package is installed using both Homebrew and Flox, this order will become important.
 
 We recommend that the Flox default environment activation lines appear lowest in your dotfiles, ensuring that packages in the default environment appear in your `PATH` sooner than those from Homebrew.
-
 
 [manifest_concept]: ../../concepts/manifest.md
 [default_tutorial]: ../default-environment.md

--- a/docs/tutorials/migrations/nvm.md
+++ b/docs/tutorials/migrations/nvm.md
@@ -10,6 +10,7 @@ Flox is an environment and package manager that allows you to install software f
 Just like [nvm](https://github.com/nvm-sh/nvm){:target="\_blank"}, Flox allows you to install and activate different versions of Node.js, enabling you to switch versions as project requirements dictate. _Unlike_ nvm, however, Flox also allows you to install just about any software you need, including databases and packages from language ecosystems like Python, Rust, Go, Java, Ruby, and others.
 
 ## Why you might want to use Flox instead of nvm
+
 nvm does exactly what it purports to do: it manages Node.js versions simply and effectively. Point notwithstanding, it's also one more dependency that you don't have to worry about if you're using Flox. Consider whether one of the following cases applies to you, or to your team:
 
 * **You work on a team with members who have diverse skill sets, and you want to have a single entrypoint for development, regardless of language ecosystem.** No matter what languages and technologies your team is comfortable with, they can use the same Flox commands to spin up their local dev environments. For example, instead of asking a Java developer who uses a Linux machine to install nvm in order to get the right node version for your project, you can offer a better solution. That developer can use the same Flox commands they use to activate their own projects to activate the dev environment for your node project, which you develop on your Mac.
@@ -18,9 +19,11 @@ nvm does exactly what it purports to do: it manages Node.js versions simply and 
 * **You need to manage versions of other JavaScript runtimes, like Bun or Deno.** While nvm is, as the name denotes, used for managing Node.js versions, that's all it does. You can use Flox to install node, but you can also use it to install different JavaScript runtimes, including [Bun](https://bun.sh/){:target="\_blank"} and [Deno](https://deno.com/){:target="\_blank"}.
 
 ## Install Flox
+
 Download and install Flox as described in our [installation instructions][install_flox]{:target="\_blank"}.
 
 ## Create a Flox environment in your existing project and install Node.js
+
 Navigate to your project's directory and run this command to initialize a Flox environment:
 
 ```sh
@@ -69,6 +72,7 @@ This should yield the following output:
 ```
 
 ## Verify the Node.js version
+
 Now that you've installed node, you activate the Flox environment to verify that it has the the version you expect.
 
 ```sh
@@ -97,6 +101,7 @@ v20.18.1
 ```
 
 ## Add Node.js and associated dependencies to a package group (optional)
+
 If you need an older version of node in your environment, we recommend that you specify a package group in your manifest to ensure that you can still install the latest versions of other software in your environment. (For more on the manifest and on package groups, read [our reference guide][manifest]{:target="\_blank"}.)
 
 At this point, you should run the following command to edit the Flox environment configuration manually:
@@ -115,6 +120,7 @@ nodejs_20 = { pkg-path = "nodejs_20", pkg-group = "node-toolchain" }
 ```
 
 ## Install other dependencies using Flox (optional)
+
 Assuming your project is like most Node.js applications, you probably have dependencies other than node to install. In this case, maybe you need PostgreSQL and nginx. Fortunately, you can install both using Flox, in the same way in which you installed node.
 
 ```sh
@@ -128,9 +134,11 @@ flox [node-project] ➜  node-project git:(main) ✗ flox install postgresql ngi
 ✅ 'postgresql' installed to environment 'node-project'
 ✅ 'nginx' installed to environment 'node-project'
 ```
+
 Now you have everything you need to develop locally, and you didn't have to figure out how to install [nginx](https://nginx.org/en/docs/install.html){:target="\_blank"} and [PostgreSQL](https://www.postgresql.org/download/){:target="\_blank"} individually.
 
 ## Update the Node.js version
+
 If you want to install a different node version, you can always update your environment to include the version you need. For example, let's say you're upgrading your project to Node.js v22. The best way to get the correct Flox Catalog version name for your desired version is to run `flox show <package>`:
 
 ```sh
@@ -172,11 +180,12 @@ nodejs_22 = { pkg-path = "nodejs_22", pkg-group = "node-toolchain", version = "n
 ```
 
 ## Update the README in your project
+
 At this point, you can replace any nvm-related instructions in your README with corresponding instructions for using Flox. In particular, instead of running `nvm use` to pick up the Node.js version from the `.nvmrc`, you can just run `flox activate`. This will install all the dependencies in your Flox environment, not just node.
 
 ## Remove nvm and related artifacts
-Now that you're managing your project's Node.js version using Flox, you can `git rm .nvmrc` and commit the result. You're free to repeat the process in other project directories before following the [instructions for uninstalling nvm as listed in the nvm README](https://github.com/nvm-sh/nvm?tab=readme-ov-file#uninstalling--removal){:target="\_blank"}.
 
+Now that you're managing your project's Node.js version using Flox, you can `git rm .nvmrc` and commit the result. You're free to repeat the process in other project directories before following the [instructions for uninstalling nvm as listed in the nvm README](https://github.com/nvm-sh/nvm?tab=readme-ov-file#uninstalling--removal){:target="\_blank"}.
 
 [environment_concept]: ../../concepts/environments.md
 [install_flox]: ../../install-flox.md


### PR DESCRIPTION
Fixes some issues that were described in this thread:

- https://flox-dev.slack.com/archives/C055P1JCP5L/p1736368190737079

**flox: Upgrade markdownlint and lychee**

I want `gitignore` support from `markdownlint-cli2` but it wasn't
available in the version that was pinned by `python.version` in the
`toplevel` package group.

I've moved `lychee` to a new group at the same time because it felt
weird having a group for a single package and I can safely verify that
these don't introduce any breaking changes.

**ci: Move markdownlint globs to config**

This fixes a bug whereby the globs were being incorrectly expanded by
the shell before being passed to `markdownlint-cli2` because they
weren't quoted as the docs suggest.

Depending on the shell in use this could cause it to:

- incorrectly miss nested directories like `docs/tutorials/migrations`
- semi-correctly miss `docs/reference/command-reference` if the glob was
  expanded before `flox activate` copies the dir from `flox/flox`

**lint: Ignore gitignored dirs (command-reference)**

We don't want to lint `docs/reference/command-reference` because the
files are already committed and copied from `flox/flox`. We may choose
to apply linting there separately.

We could use `!docs/reference/command-reference` in the glob patterns
but it feels more reliable to depend on the gitignore rules that we
already have in case the path changes at any time.

**lint: Auto-fix omitted migrations dir**

These were inconsistently linted until a recent commit that moved the
globbing to the config. This is the result of running:

    markdownlint-cli2 --fix