### PR TITLE
feat: add build and publish concept pages

### DIFF
--- a/check_links.sh
+++ b/check_links.sh
@@ -9,4 +9,5 @@ lychee $SCRIPT_DIR/site \
   -nv \
   --remap "https://flox.dev/docs file://$PWD/site" \
   --exclude "bash/manual/html_node" \
-  --exclude "https://www.gnu.org/software/make/"
+  --exclude "https://www.gnu.org/software/make/" \
+  --exclude "https://github.com/flox/catalog-util"

--- a/docs/concepts/manifest-builds.md
+++ b/docs/concepts/manifest-builds.md
@@ -1,5 +1,5 @@
 ---
-title: "Preview: Builds"
+title: "Builds"
 description: How to use Flox environments to build artifacts 
 ---
 
@@ -9,44 +9,27 @@ That could be a compiled executable, an archive containing source files, or
 something else entirely.
 A Flox environment ensures that the same set of tools, dependencies, and
 environment variables are available wherever the environment is activated.
-You can now integrate builds into your environment to build those artifacts
-with the same reproducible set of tools and dependencies that were used to
-develop the software.
-
-## Enabling builds
-
-Builds are still in development,
-so before you can perform builds you will need to enable a feature flag.
-
-To enable the builds feature temporarily you can set an environment variable:
-
-```bash
-$ export FLOX_FEATURES_BUILD=true
-```
-
-To make this feature flag persistent you can edit your Flox config:
-
-```bash
-$ flox config --set-bool features.build true
-```
+You can now perform builds in the context of that environment so that you have
+access to the same set of tools, scripts, and environment variables available
+during your builds as you do during development.
 
 ## Defining builds
 
 Builds are defined in the `[build]` section of the manifest.
-Configuring a build mostly entails providing a short Bash script to run to
-build the artifact.
-This script is run inside the environment so that the tools used to develop
-the software are available during the build.
-
 Each build specified in the `[build]` section corresponds to a different
 artifact.
 This allows you to produce multiple artifacts from a given set of sources,
 for example to produce different versions of a compiled binary both with
 and without debug symbols.
 
-Finally, `flox` requires that you place your artifacts into a directory called
-`$out`,
-but we'll provide more details on that aspect later.
+Configuring a build mostly entails providing a short Bash script containing the
+instructions to build the artifact.
+This script often contains the same commands you would normally run to build
+the artifact in your shell e.g. `make`, `cargo build`, etc.
+Flox runs this script inside an activation of the environment so that the tools
+used to develop the software are available during the build.
+The script must also place the artifact into a directory called `$out`,
+but we'll provide more details on that aspect in just a moment.
 
 An example build definition for a Rust project called `myproject` looks like
 this:
@@ -61,56 +44,6 @@ command = '''
 ```
 
 As you can see, it's very simple.
-
-### Limiting the package size
-
-Your artifact likely has dependencies,
-and those dependencies have their own dependencies,
-all the way down to `libc`.
-We call this complete set of dependencies the "transitive closure",
-or simply "the closure", of your artifact.
-A large closure for your artifact has no direct impact on runtime performance,
-but it means that your artifact requires more disk space to install and requires
-more bandwidth to copy from one place to another.
-
-By default all of the packages in the default [package group][pkg-groups] are
-included as dependencies of your artifacts,
-but these packages may only be needed by your artifact at _build_ time,
-not _run_ time.
-As a reminder, the default package group is called `toplevel`,
-and all packages installed to an environment without an explicit `pkg-group`
-are placed into this package group.
-
-You can restrict the dependencies needed at runtime via the `runtime-packages`
-option by listing the `install-id`s
-of the dependencies required at runtime:
-
-```toml
-version = 1
-
-[install]
-hello.pkg-path = "hello-go"
-ripgrep.pkg-path = "ripgrep"
-
-[build.hello-pkg]
-command = '''
-  mkdir -p $out/bin
-  echo "hello-go" > $out/bin/hello-pkg
-  chmod +x $out/bin/hello-pkg
-'''
-runtime-packages = [ "hello" ] # List of `install-id`s
-
-[options]
-systems = ["aarch64-darwin", "x86_64-darwin", "aarch64-linux", "x86_64-linux"]
-```
-
-In the example manifest above we install two packages, `hello-go` and `ripgrep`,
-and build an artifact that runs the `hello-go` package, called `hello-pkg`.
-By setting `runtime-packages = [ "hello" ]`
-(the `install-id` of the `hello-go` package is `hello`),
-we limit the runtime closure of the `hello-pkg` artifact
-to only the `hello-go` package,
-eliminating `ripgrep`.
 
 ### Where to put artifacts
 
@@ -140,32 +73,7 @@ What this means in practice is:
   marked as executable via `chmod +x`.
 - Man pages should be placed in `$out/share/man`.
 - Libraries should be placed in `$out/lib`
-
-### Sandboxed builds
-
-The script that you specify in `command` is run on your host machine by default.
-This means that it may build against dependencies that are outside of your
-environment and the artifact may not function correctly when executed or rebuilt
-from another machine.
-
-In order to improve the reproducibility of your build you can specify that it is
-run within a sandbox that doesn't have access to the host machine:
-
-```toml
-[build.myproject]
-sandbox = "pure"
-command = '''
-  cargo build --release
-  mkdir -p $out/bin
-  cp target/release/myproject $out/bin/myproject
-'''
-```
-
-The project has to be within a Git repository and only committed files are
-available within the sandbox.
-
-On Linux machines the sandbox also prevents the build from accessing the
-network.
+- Configuration should be placed in `$out/etc`.
 
 ## Performing builds
 
@@ -190,6 +98,134 @@ after the build you could run the compiled binary via
 $ ./result-myproject/bin/myproject
 ```
 
+## What can you build?
+
+The obvious answer to this question is, of course, "software",
+but this omits a variety of interesting use cases that may not be immediately
+obvious.
+
+At the end of the day, a "build" is just a script that runs in your activated
+environment and places one or more files into a predefined directory.
+Once that build is done, the artifact can be [published][publish-concept] so
+that anyone else in your organization can install it into their environment.
+This can be a very convenient method of distributing files.
+
+In short, if you have a file that can be copied into the `$out` directory,
+it can be distributed to others in your organization with Flox.
+
+### Example: configuration files
+
+Say that Nginx is used as a web server throughout your organization, and there
+is some common configuration that you want every instance to include
+(e.g. always list on the same local port, etc).
+Flox environments don't allow you to package arbitrary files along with them,
+but a build that produces this config file can be published and then consumed
+by anyone with access to your private catalog.
+
+That build would be very simple:
+
+```toml
+[build.nginx_config]
+command = '''
+  mkdir -p $out/etc
+  cp nginx.conf $out/etc/nginx.conf
+'''
+```
+
+Any environment that installs this package after it has been published would
+then be able to reference the config file as `$FLOX_ENV/etc/nginx.conf`.
+
+### Example: protocol buffers
+
+Say that your organization uses [grpc][grpc] to communicate between services.
+You could vendor the `.proto` files in your project's repository, or store
+the `.proto` files in a separate repository.
+However, you could also write a build that copies these `.proto` files and
+publish the artifact.
+This allows you to version and attach metadata to the `.proto` files,
+and any team that "installs" the artifact would have access to them.
+
+Furthermore, since these `.proto` files are installed as a package,
+any environment that installs them would be notified when there are updates
+available.
+
+## Limiting the package size
+
+Your artifact likely has dependencies,
+and those dependencies have their own dependencies,
+all the way down to `libc`.
+We call this complete set of dependencies the "transitive closure",
+or simply "the closure", of your artifact.
+A large closure for your artifact has no direct impact on runtime performance,
+but it means that your artifact requires more disk space to install and requires
+more bandwidth to copy from one place to another.
+
+By default all of the packages in the default [package group][pkg-groups] are
+included as dependencies of your artifacts,
+but these packages may only be needed by your artifact at _build_ time or _development_ time,
+not _run_ time.
+As a reminder, the default package group is called `toplevel`,
+and all packages installed to an environment without an explicit `pkg-group`
+are placed into this package group.
+
+The `runtime-packages` option allows you to trim down the packages from the `toplevel`
+package group that are included as runtime dependencies of your artifact.
+This option is a list of `install-id`s from the `toplevel` package group.
+As a reminder, the `install-id` is the part of the package descriptor that
+comes before `pkg-path` e.g. `myhello` in `myhello.pkg-path = "hello"`.
+
+Below is an example manifest that installs two packages needed for development,
+`hello-go` and `ripgrep`, and restricts the runtime dependencies of the build to
+only `hello-go` (omitting `ripgrep`):
+
+```toml
+version = 1
+
+[install]
+hello.pkg-path = "hello-go"
+ripgrep.pkg-path = "ripgrep"
+
+[build.hello-pkg]
+command = '''
+  mkdir -p $out/bin
+  echo "hello-go" > $out/bin/hello-pkg
+  chmod +x $out/bin/hello-pkg
+'''
+runtime-packages = [ "hello" ] # List of `install-id`s
+
+[options]
+systems = ["aarch64-darwin", "x86_64-darwin", "aarch64-linux", "x86_64-linux"]
+```
+
+Note again that we include the `install-id` `"hello"` in `runtime-packages`,
+not the name of the package itself (`hello-go`).
+
+## Sandboxed builds
+
+The script that you specify in `command` is run on your host machine by default.
+This means that it may build against dependencies that are outside of your
+environment and the artifact may not function correctly when executed or rebuilt
+on another machine.
+
+In order to improve the reproducibility of your build you can specify that it is
+run within a sandbox that doesn't have access to the host machine:
+
+```toml
+[build.myproject]
+sandbox = "pure" # enable the sandbox
+command = '''
+  cargo build --release
+  mkdir -p $out/bin
+  cp target/release/myproject $out/bin/myproject
+'''
+```
+
+The project has to be within a Git repository, and only committed files are
+available within the sandbox.
+
+On Linux machines the sandbox also prevents the build from accessing the
+network.
+
 ## Examples
 
 We've compiled a list of example commands to demonstrate how to use Flox to
@@ -197,6 +233,8 @@ build artifacts in various ecosystems.
 You can see that page here: [Builds examples][build-examples].
 
 [services-concept]: ./services.md
+[publish-concept]: ./publishing.md
 [fhs-docs]: https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard
 [pkg-groups]: ./manifest.md#installing-packages-to-package-groups
 [build-examples]: ../cookbook/builds/examples.md
+[grpc]: https://grpc.io/

--- a/docs/concepts/packages-and-catalog.md
+++ b/docs/concepts/packages-and-catalog.md
@@ -9,19 +9,18 @@ The **Flox Catalog** is a searchable index of **packages** that you can explore 
 [flox search][flox_search], [flox show][flox_show], and then [flox install][flox_install] to your
 environments.
 
-It can also be consulted on https://hub.flox.dev/packages.
-
-The built-in catalog contains a wide variety of open source packages you can use
-in your environments.
+It can also be consulted on [https://hub.flox.dev/packages](https://hub.flox.dev/packages).
 
 A **package** is a collection of computer programs and related data that are
 bundled for distribution together on a UNIX-based computer system.
 Packages are declared in the [environment manifest][manifest_concept].
 
-## Flox Catalog and nixpkgs
+## Base Catalog and nixpkgs
 
-The Flox Catalog uses [nixpkgs][nixpkgs] as an input.
-Upstream changes in [nixpkgs][nixpkgs] are reflected in the Flox Catalog daily from the unstable branch of [nixpkgs][nixpkgs].
+The built-in catalog is called the Base Catalog, and contains a wide variety of open source packages you can use in your environments.
+The Base Catalog uses [nixpkgs][nixpkgs] as an input.
+Nixpkgs is a community maintained project, but the Base Catalog is maintained by Flox.
+Upstream changes in [nixpkgs][nixpkgs] are reflected in the Flox Catalog daily from the `unstable` branch of [nixpkgs][nixpkgs].
 
 ## Supported package metadata
 

--- a/docs/concepts/publishing.md
+++ b/docs/concepts/publishing.md
@@ -53,35 +53,36 @@ A published artifact consists of two parts:
 - The artifact itself
 
 The artifact metadata is uploaded to Flox servers so that the Flox CLI can see that it's available via the `flox search`, `flox show`, and `flox install` commands.
-The artifact itself is uploaded to the store.
+The artifact itself is uploaded to a Catalog Store.
 
 Today that store is user-provided, but a hosted offering will be provided in the future.
-However, when the store is user-provided it means that your organization has complete control over your artifacts, and many organizations will still choose this route even when a hosted option is available.
+When the store is user-provided it means that your organization has complete control over your artifacts, and many organizations will still choose this route even when a hosted option is available.
 
 ## Consuming published artifacts
 
 Once you have uploaded an artifact via `flox publish`, the package becomes available in `flox search`, `flox show`, and `flox install`.
-To distinguish these packages from those provided by the Base Catalog, published packages are prefixed with the name of the organization and a slash e.g. `myorg/hello`.
+To distinguish these packages from those provided by the Base Catalog, published packages are prefixed with the name of the organization.
+For example, if your organization is called `myorg` and it publishes an artifact named `hello`, the artifact will appear as `myorg/hello` in the Flox CLI.
 
-When a user runs `flox install myorg/hello`, the artifact is downloaded directly from the store that it was published to.
+When a user runs `flox install myorg/hello`, the artifact is downloaded directly from the Catalog Store that it was published to.
 
 By default, only the owner of the private catalog has access to artifacts published to it.
 Individual users can be added to an allowlist able to access artifacts in the private catalog via the [catalog-util][catalog-util] command line tool.
 
 ## Configuration
 
-### Flox Store
+### Catalog Store
 
-The Flox CLI uses Nix under the hood to perform certain operations, and must be configured to be made aware of the user-provided Flox Store.
-A Flox Store is an S3-compatible service
-See the "Flox Store" cookbook page to learn more about how to provision the service.
+The Flox CLI uses Nix under the hood to perform certain operations, and must be configured to be made aware of the user-provided Catalog Store.
+A Catalog Store is an S3-compatible service.
+See the "Catalog Store" cookbook page to learn more about how to provision the service.
 
 ### Signing key
 
-Artifacts uploaded to a Flox Store must be signed.
-This key must be provided to Flox via the `flox publish --signing-key` argument so that the key can be used to sign artifacts during the publish process.
+Artifacts uploaded to a Catalog Store may be signed.
+This key is provided to Flox via the `flox publish --signing-key` argument so that the key can be used to sign artifacts during the publish process.
 Similarly, in order to install packages signed with this key, Nix must be configured to trust this key.
-See the "Flox Store" cookbook page to learn more about how to configure Nix to trust the signing key.
+See the "Catalog Store" cookbook page to learn more about how to configure Nix to trust the signing key.
 
 [builds-concept]: ./manifest-builds.md
 [early]: https://flox.dev/early/

--- a/docs/concepts/publishing.md
+++ b/docs/concepts/publishing.md
@@ -1,0 +1,87 @@
+---
+title: "Publishing"
+description: How to use Flox environments to build artifacts 
+---
+
+!!! tip "This is a Flox for Teams feature"
+
+    This is a paid feature included with Flox for Teams.
+    Sign up for [early access][early] if you are interested in accessing this feature.
+  
+Once you've built an artifact with the [`flox build`][builds-concept] command, you likely want to put it somewhere.
+The `flox publish` command gives you the ability to upload artifacts to your private catalog so that they can be installed by anyone in your organization.
+
+## Uploading an artifact
+
+The `flox publish <name>` command allows you to upload an artifact built with the `flox build` command, where `<name>` is the name of any build listed in the `build` section of the manifest.
+
+```toml
+# manifest.toml
+[build.mypkg]
+command = '''
+  ...
+'''
+```
+
+```console
+$ flox publish mypkg
+```
+
+## Publish process
+
+In order to make sure that the uploaded artifact can be built reproducibly,
+Flox imposes some constraints on the build and publish process.
+
+- The Flox environment performing the build must tracked in a git repository.
+- Tracked files in the git repository must be clean.
+- The git repository has a remote defined, and the current revision has been pushed to it.
+- The Flox environment must have at least one package installed to it.
+
+All of this is there to ensure that the build environment isn't dirty and that we can associate the uploaded artifact with a point in time in the Base Catalog.
+
+As part of the `flox publish` command, the CLI will clone the git repository to a temporary directory to ensure that any files referenced in the build are tracked by the repository.
+A clean `flox build` is then run in this directory.
+
+The package closure is then signed with the user-supplied signing key and uploaded to the organization's private catalog.
+
+## The published payload
+
+A published artifact consists of two parts:
+
+- The artifact metadata
+- The artifact itself
+
+The artifact metadata is uploaded to Flox servers so that the Flox CLI can see that it's available via the `flox search`, `flox show`, and `flox install` commands.
+The artifact itself is uploaded to the store.
+
+Today that store is user-provided, but a hosted offering will be provided in the future.
+However, when the store is user-provided it means that your organization has complete control over your artifacts, and many organizations will still choose this route even when a hosted option is available.
+
+## Consuming published artifacts
+
+Once you have uploaded an artifact via `flox publish`, the package becomes available in `flox search`, `flox show`, and `flox install`.
+To distinguish these packages from those provided by the Base Catalog, published packages are prefixed with the name of the organization and a slash e.g. `myorg/hello`.
+
+When a user runs `flox install myorg/hello`, the artifact is downloaded directly from the store that it was published to.
+
+By default, only the owner of the private catalog has access to artifacts published to it.
+Individual users can be added to an allowlist able to access artifacts in the private catalog via the [catalog-util][catalog-util] command line tool.
+
+## Configuration
+
+### Flox Store
+
+The Flox CLI uses Nix under the hood to perform certain operations, and must be configured to be made aware of the user-provided Flox Store.
+A Flox Store is an S3-compatible service
+See the "Flox Store" cookbook page to learn more about how to provision the service.
+
+### Signing key
+
+Artifacts uploaded to a Flox Store must be signed.
+This key must be provided to Flox via the `flox publish --signing-key` argument so that the key can be used to sign artifacts during the publish process.
+Similarly, in order to install packages signed with this key, Nix must be configured to trust this key.
+See the "Flox Store" cookbook page to learn more about how to configure Nix to trust the signing key.
+
+[builds-concept]: ./manifest-builds.md
+[early]: https://flox.dev/early/
+[catalog-util]: https://github.com/flox/catalog-util

--- a/docs/concepts/publishing.md
+++ b/docs/concepts/publishing.md
@@ -38,6 +38,7 @@ Flox imposes some constraints on the build and publish process.
 - The Flox environment must have at least one package installed to it.
 
 All of this is there to ensure that the build environment isn't dirty and that we can associate the uploaded artifact with a point in time in the Base Catalog.
+As a reminder, the Base Catalog is the built-in [catalog][catalog-concept] provided by Flox.
 
 As part of the `flox publish` command, the CLI will clone the git repository to a temporary directory to ensure that any files referenced in the build are tracked by the repository.
 A clean `flox build` is then run in this directory.
@@ -85,3 +86,4 @@ See the "Flox Store" cookbook page to learn more about how to configure Nix to t
 [builds-concept]: ./manifest-builds.md
 [early]: https://flox.dev/early/
 [catalog-util]: https://github.com/flox/catalog-util
+[catalog-concept]: ./packages-and-catalog.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,7 +52,7 @@ nav:
     - Generations: concepts/generations.md
     - Catalog and Packages: concepts/packages-and-catalog.md
     - Services: concepts/services.md
-    - "Preview: Builds": concepts/manifest-builds.md
+    - Builds: concepts/manifest-builds.md
     - Flox vs. container workflows: concepts/flox-vs-containers.md
   - Cookbook:
     - Languages:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
     - Catalog and Packages: concepts/packages-and-catalog.md
     - Services: concepts/services.md
     - Builds: concepts/manifest-builds.md
+    - Publishing: concepts/publishing.md
     - Flox vs. container workflows: concepts/flox-vs-containers.md
   - Cookbook:
     - Languages:


### PR DESCRIPTION
This change reworks the existing build concept page and adds a publishing concept page. In the future there will be links to other pages that are currently in progress.