### PR TITLE
feat: rewrite customizing environments

### DIFF
--- a/.flox/env/manifest.lock
+++ b/.flox/env/manifest.lock
@@ -45,9 +45,9 @@
     },
     "profile": {
       "common": "echo \"\"\necho \"     ╔═══════════════════════════════════╗\"\necho \"     ║                                   ║\"\necho \"     ║  To build a production docs run:  ║\"\necho \"     ║  > mkdocs build                   ║\"\necho \"     ║                                   ║\"\necho \"     ║  To write docs locally run:       ║\"\necho \"     ║  > mkdocs serve                   ║\"\necho \"     ║                                   ║\"\necho \"     ╚═══════════════════════════════════╝\"\necho \"\"\n",
-      "bash": "  source \"$(poetry env info --path)/bin/activate\"\n",
-      "zsh": "  source \"$(poetry env info --path)/bin/activate\"\n",
-      "fish": "  source \"$(poetry env info --path)/bin/activate.fish\"\n",
+      "bash": "  source \"$(poetry env info --path)/bin/activate\"\n  alias lint=markdownlint-cli2\n",
+      "zsh": "  source \"$(poetry env info --path)/bin/activate\"\n  alias lint=markdownlint-cli2\n",
+      "fish": "  source \"$(poetry env info --path)/bin/activate.fish\"\n  alias lint markdownlint-cli2\n",
       "tcsh": "  source \"$(poetry env info --path)/bin/activate.csh\"\n"
     },
     "options": {

--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -138,15 +138,18 @@ echo ""
 '''
 bash = '''
   source "$(poetry env info --path)/bin/activate"
+  alias lint=markdownlint-cli2
 '''
 fish = '''
   source "$(poetry env info --path)/bin/activate.fish"
+  alias lint markdownlint-cli2
 '''
 tcsh = '''
   source "$(poetry env info --path)/bin/activate.csh"
 '''
 zsh = '''
   source "$(poetry env info --path)/bin/activate"
+  alias lint=markdownlint-cli2
 '''
 
 # The `[services]` section of the manifest allows you to define services.

--- a/docs/tutorials/customizing-environments.md
+++ b/docs/tutorials/customizing-environments.md
@@ -108,7 +108,7 @@ Similarly, editing the `[vars]` section has no effect on the currently activated
 
 ## Enabling feature flags
 
-Now let's say that you've worked on `mycli` for a while and developed some features that aren't publically available, but can be accessed by setting certain feature flags.
+Now let's say that you've worked on `mycli` for a while and developed some features that aren't publicly available, but can be accessed by setting certain feature flags.
 A common way to enable or disable feature flags is by environment variables.
 If you want to be able to test out those features during development, this sounds like a great thing for Flox to do for you automatically.
 
@@ -146,7 +146,7 @@ This means that we'll be adding it to the `[profile]` section.
 However, the syntax for defining shell aliases is shell-specific, so we'll need to declare this alias in the subsection that corresponds to our shell.
 For this tutorial we'll assume that you're an enlightened [fish shell][fish_shell] user, meaning that we'll edit our `profile.fish` script.
 
-We'll call this alias `install-bin` and it will build `mycli` in "release" mode e.g. with full optimizations so it runs as fast as possible.
+We'll call this alias `install-bin` and it will build `mycli` in "release" mode, i.e. with full optimizations so it runs as fast as possible.
 Edit your `[profile]` section to look like this:
 
 ```toml
@@ -173,6 +173,7 @@ mycli
 
 - :simple-readme:{ .flox-purple .flox-heart } [Multiple architecture environments][multi-arch-guide]
 
+[environment_concept]: ../concepts/environments.md
 [flox_activate]: ../reference/command-reference/flox-activate.md
 [multi-arch-guide]: ./multi-arch-environments.md
 [rust_guide]: ../cookbook/languages/rust.md

--- a/docs/tutorials/customizing-environments.md
+++ b/docs/tutorials/customizing-environments.md
@@ -42,6 +42,7 @@ The logic for deciding where a customization should go is application specific, 
 For a full discussion of what logic to place in which section and why, see the [activation concept page][activation_concept].
 Otherwise, try this:
 
+<!-- markdownlint-disable MD007 -->
 - Are you setting an environment variable?
     - Is it a constant value?
         - If so, set it in the `[vars]` section.
@@ -52,6 +53,7 @@ Otherwise, try this:
     - If so, set them in the `[profile]` section.
 - Are you doing general project setup actions (like creating a directory, etc)?
     - If so, do that in the `hook.on-activate` script.
+<!-- markdownlint-enable MD007 -->
 
 ## Adding a directory to PATH
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,7 +40,7 @@ nav:
     - The default environment: tutorials/default-environment.md
     - Sharing environments: tutorials/sharing-environments.md
     - Layering multiple environments: tutorials/layering-multiple-environments.md
-    - Customizing the environment shell hook: tutorials/customizing-environments.md
+    - Customizing the shell environment: tutorials/customizing-environments.md
     - Running Flox in CI/CD: tutorials/ci-cd.md
     - Designing cross-platform environments: tutorials/multi-arch-environments.md
     - Reusing and combining developer environments: tutorials/composition.md


### PR DESCRIPTION
This previously focused exclusively on shell hooks and used them to run a service. This now shows a user how to leverage the hook, profile, and vars sections to customize their shell environment in an activated environment.