### PR TITLE
feat: extra pure build instructions

### DIFF
--- a/docs/cookbook/languages/go.md
+++ b/docs/cookbook/languages/go.md
@@ -12,11 +12,6 @@ See the [builds][build-concept] concept page for more details.
 
 Since the output of the build must be copied to the `$out` directory, you may either install the output directly to `$out`, or you may copy the executable there manually after running `go build`.
 
-Go adds metadata to compiled binaries that allows details from the build environment to leak through.
-For example, a compiled binary will contain absolute paths to source files.
-This can cause builds to fail as it interferes with Flox's ability to determine when a build depends on an artifact that aren't included in the build's closure, i.e. when a build has missing dependencies.
-To address this you'll need to compile your programs with the `-trimpath` option.
-
 Install directly to `$out`:
 
 ```toml
@@ -37,4 +32,55 @@ command = '''
 '''
 ```
 
+### Go compiler adds metadata
+
+Go adds metadata to compiled binaries that allows details from the build environment to leak through.
+For example, a compiled binary will contain absolute paths to source files.
+This can cause builds to fail as it interferes with Flox's ability to determine when a build depends on an artifact that aren't included in the build's closure, i.e. when a build has missing dependencies.
+To address this you'll need to compile your programs with the `-trimpath` option.
+
+### Go builds depend on iana, mailcap, tzdata
+
+The Go `net/http` package has a few runtime dependencies that you may not know you depend on:
+
+- `iana-etc`: used to resolve a protocol or service by name.
+- `mailcap`: used to resolve MIME types.
+- `tzdata`: used to resolve timezones.
+
+You'll need to add those packages to your environment and add them to the `runtime-packages` of your build if you're limiting which packages are present at runtime:
+
+```toml
+runtime-packages = [
+  "iana-etc",
+  "mailcap",
+  "tzdata",
+]
+```
+
+### Vendoring dependencies in pure builds
+
+As discussed in the [pure builds][pure-builds-section] of the Builds concept page, pure builds run in a sandbox without network access on Linux.
+A pure build can be run as a multi-stage build where the first step vendors dependencies.
+An example is shown below:
+
+```toml
+[build.myproject-deps]
+command = '''
+  export GOMODCACHE=$out
+  go mod download -modcacherw
+'''
+
+[build.myproject]
+command = """
+  export GOMODCACHE=${myproject-deps}
+  mkdir -p "$out/bin"
+  go build -trimpath -o $out/bin/myproject
+  chmod +x $out/bin/myproject
+"""
+sandbox = "pure"
+
+```
+
+
 [build-concept]: ../../concepts/manifest-builds.md
+[pure-build-section]: ../../concepts/manifest-builds.md#pure-builds

--- a/docs/cookbook/languages/nodejs.md
+++ b/docs/cookbook/languages/nodejs.md
@@ -48,4 +48,30 @@ chmod 755 $out/bin/myproject
 
 2. If your `npm build` already produces a binary that can be executed drectly, you can also copy or link that to `$out/bin`. Note that only binaries in `$out/bin` are wrapped to ensure they run within a consistent environment.
 
+### Vendoring dependencies in pure builds
+
+As discussed in the [pure builds][pure-builds-section] of the Builds concept page, pure builds run in a sandbox without network access on Linux.
+A pure build can be run as a multi-stage build where the first step vendors dependencies.
+An example is shown below:
+
+```toml
+[build.myproject-deps]
+command = '''
+  mkdir -p $out
+  npm ci
+  cp -r node_modules $out
+'''
+
+[build.myproject]
+command = '''
+  # Copy node modules built in the previous step
+  cp --no-preserve=mode -r ${myproject-deps}/node_modules ./
+  ...
+  # The rest of the build is the same
+'''
+sandbox = "pure"
+```
+
+
 [build-concept]: ../../concepts/manifest-builds.md
+[pure-builds-section]: ../../concepts/manifest-builds.md#pure-builds


### PR DESCRIPTION
This adds instructions for pure builds in various languages since it may not be obvious how to accomplish the vendoring step or do a multi-stage build.