### PR TITLE
docs(nef): Tweak overrideAttrs naming

### DIFF
--- a/docs/concepts/nix-expression-builds.md
+++ b/docs/concepts/nix-expression-builds.md
@@ -137,7 +137,7 @@ If the latest version of a package isn't yet available in the Flox Catalog then 
 ```nix title=".flox/pkgs/hello.nix"
 { hello, fetchurl }:
 
-hello.overrideAttrs (finalAttrs: old: {
+hello.overrideAttrs (finalAttrs: oldAttrs: {
   version = "2.12.2";
   src = fetchurl {
     url = "mirror://gnu/hello/hello-${finalAttrs.version}.tar.gz";
@@ -153,11 +153,11 @@ If you want to apply a patch, such as an unreleased bug fix, to an existing pack
 ```nix title=".flox/pkgs/hello-shouty/default.nix"
 { hello }:
 
-hello.overrideAttrs (old: {
-  patches = (old.patches or []) ++ [
+hello.overrideAttrs (oldAttrs: {
+  patches = (oldAttrs.patches or []) ++ [
     ./shouty.patch
   ];
-  meta = old.meta // {
+  meta = oldAttrs.meta // {
     description = "A patched version of hello that shouts the default greeting.";
   };
 })

--- a/docs/concepts/nix-expression-builds.md
+++ b/docs/concepts/nix-expression-builds.md
@@ -137,7 +137,7 @@ If the latest version of a package isn't yet available in the Flox Catalog then 
 ```nix title=".flox/pkgs/hello.nix"
 { hello, fetchurl }:
 
-hello.overrideAttrs (finalAttrs: oldAttrs: {
+hello.overrideAttrs (finalAttrs: _oldAttrs: {
   version = "2.12.2";
   src = fetchurl {
     url = "mirror://gnu/hello/hello-${finalAttrs.version}.tar.gz";


### PR DESCRIPTION
**docs(nef): Rename old -> oldAttrs**

To make it clearer that these are attrs.

The docs refer to these as `previousAttrs` but there's very little usage
of that in the single argument form in `nixos/nixpkgs`, where there's
mostly a 50:50 split between `old` and `oldAttrs`:

- https://nixos.org/manual/nixpkgs/stable/#sec-pkg-overrideAttrs
- https://github.com/search?q=repo%3ANixOS%2Fnixpkgs+overrideAttrs+old&type=code
- https://github.com/search?q=repo%3ANixOS%2Fnixpkgs+overrideAttrs+previousattrs&type=code

**docs(nef): Indicate unused oldAttrs**

We only need access to `finalAttrs` from the two argument form of
`overrideAttrs` so underscore the `oldAttrs` to make it clear that it's
not in use whilst still indicating it's name.

From https://nixos.org/manual/nixpkgs/stable/#sec-pkg-overrideAttrs

> The argument previousAttrs is conventionally used to refer to the attr
> set originally passed to stdenv.mkDerivation.
>
> The argument finalAttrs refers to the final attributes passed to
> mkDerivation, plus the finalPackage attribute which is equal to the
> result of mkDerivation or subsequent overrideAttrs calls.
>
> If only a one-argument function is written, the argument has the
> meaning of previousAttrs.
>
> Function arguments can be omitted entirely if there is no need to
> access previousAttrs or finalAttrs.