### PR TITLE
docs(nef): Add experimental-features to command

### DIFF
--- a/docs/concepts/nix-expression-builds.md
+++ b/docs/concepts/nix-expression-builds.md
@@ -197,7 +197,10 @@ diff -ru hello-2.12.2/tests/hello-1 hello-patched/tests/hello-1
 Typically you would only override specific attributes of an existing package, which allows you to continue benefiting from upstream changes and surface failures if there are any conflicts, but if you want to copy a package to make more fundamental changes or because it's being removed upstream:
 
 ```sh
-EDITOR=cat nix edit 'nixpkgs#hello' > .flox/pkgs/hello.nix
+EDITOR=cat \
+  nix --extra-experimental-features "nix-command flakes" \
+  edit 'nixpkgs#hello' \
+  > .flox/pkgs/hello.nix
 ```
 
 This will extract the expression for the `hello` package in `nixpkgs` and save the contents to file which can then be modified.


### PR DESCRIPTION
Michael noted after demos that this doesn't work with the default Nix config that is installed with Flox.

The original suggestion was to not use flakes, which I adapted because it was kinder on the eyes for people that have used flakes, but that also fails without `nix-command`:

    % NIX_CONFIG="experimental-features = " EDITOR=cat nix edit -f '<nixpkgs>' hello
    error: experimental Nix feature 'nix-command' is disabled; add '--extra-experimental-features nix-command' to enable it