### PR TITLE
docs(sharing): Clarify what activate does

### DIFF
--- a/docs/tutorials/sharing-environments.md
+++ b/docs/tutorials/sharing-environments.md
@@ -47,7 +47,7 @@ $ git add .flox
 $ git commit -m "sharing flox environment"
 ```
 
-Another developer on the same project can get started immediately with [`flox activate`][flox_activate]
+Another developer on the same project can get started immediately with [`flox activate`][flox_activate], which will automatically download the same versions of those packages to their machine:
 
 ```
 $ git clone ..example-project


### PR DESCRIPTION
Sebastian Schuberth noted in Slack that it wasn't clear `activate` would download packages that were previously `flox install`ed into an env:

- https://floxcommunitygroup.slack.com/archives/C06NYALM8P8/p1753282180636659

Clarify this by noting that it's the same environment and packages.