### PR TITLE
fix: Lint and fix broken reference links

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -10,7 +10,6 @@ config:
 
   # May not play well with mkdocs processing.
   no-bare-urls: false
-  reference-links-images: false
   link-image-reference-definitions: false
 
   # Take care fixing.

--- a/docs/cookbook/languages/go.md
+++ b/docs/cookbook/languages/go.md
@@ -90,4 +90,4 @@ sandbox = "pure"
 ```
 
 [build-concept]: ../../concepts/builds.md
-[pure-build-section]: ../../concepts/manifest-builds.md#pure-builds
+[pure-builds-section]: ../../concepts/manifest-builds.md#pure-builds


### PR DESCRIPTION
I found a broken link while working on NEF docs and found that we can check these in CI:

- https://github.com/DavidAnson/markdownlint/blob/main/doc/md052.md

Output before the fix:

    % markdownlint-cli2
    markdownlint-cli2 v0.18.1 (markdownlint v0.38.0)
    Finding: docs/**/*.md
    Linting: 39 file(s)
    Summary: 1 error(s)
    docs/cookbook/languages/go.md:71:21 MD052/reference-links-images Reference links and images should use a label that is defined [Missing link or image reference definition: "pure-builds-section"] [Context: "[pure builds][pure-builds-section]"]