### PR TITLE
docs(cookbooks): Add NEF examples

### DIFF
--- a/docs/cookbook/languages/c.md
+++ b/docs/cookbook/languages/c.md
@@ -10,7 +10,9 @@ description: Common questions and solutions for using C with Flox
 Not only can you _develop_ your software with Flox, but you can _build_ it as well.
 See the [builds][build-concept] concept page for more details.
 
-### Autotools
+### Manifest builds
+
+#### Autotools
 
 Since `autotools` isn't specific to C, this example will also work for any project using `autotools`.
 Since the output of the build must be copied to the `$out` directory, you must set the install prefix to `$out`.
@@ -24,7 +26,7 @@ command = '''
 '''
 ```
 
-### CMake
+#### CMake
 
 Doing a `CMake` build looks much the same as `autotools`.
 
@@ -35,6 +37,22 @@ command = '''
   make
   make install PREFIX=$out
 '''
+```
+
+### Nix expression builds
+
+To build a project using `clang`:
+
+```nix
+{ clangStdenv }:
+
+clangStdenv.mkDerivation {
+  pname = "myproject";
+  version = "0.0.1";
+  src = ../../.;
+
+  installFlags = [ "PREFIX=$(out)" ];
+}
 ```
 
 [build-concept]: ../../concepts/builds.md

--- a/docs/cookbook/languages/go.md
+++ b/docs/cookbook/languages/go.md
@@ -10,6 +10,8 @@ description: Common questions and solutions for using Go with Flox
 Not only can you _develop_ your software with Flox, but you can _build_ it as well.
 See the [builds][build-concept] concept page for more details.
 
+### Manifest builds
+
 Since the output of the build must be copied to the `$out` directory, you may either install the output directly to `$out`, or you may copy the executable there manually after running `go build`.
 
 Install directly to `$out`:
@@ -32,14 +34,14 @@ command = '''
 '''
 ```
 
-### Go compiler adds metadata
+#### Go compiler adds metadata
 
 Go adds metadata to compiled binaries that allows details from the build environment to leak through.
 For example, a compiled binary will contain absolute paths to source files.
 This can cause builds to fail as it interferes with Flox's ability to determine when a build depends on an artifact that aren't included in the build's closure, i.e. when a build has missing dependencies.
 To address this you'll need to compile your programs with the `-trimpath` option.
 
-### Go builds depend on iana, mailcap, tzdata
+#### Go builds depend on iana, mailcap, tzdata
 
 The Go `net/http` package has a few runtime dependencies that you may not know you depend on:
 
@@ -66,7 +68,7 @@ runtime-packages = [
 ]
 ```
 
-### Vendoring dependencies in pure builds
+#### Vendoring dependencies in pure builds
 
 As discussed in the [pure builds][pure-builds-section] of the Builds concept page, pure builds run in a sandbox without network access on Linux.
 A pure build can be run as a multi-stage build where the first step vendors dependencies.
@@ -89,5 +91,22 @@ command = """
 sandbox = "pure"
 ```
 
+### Nix expression builds
+
+To build a project using [`buildGoModule`](https://nixos.org/manual/nixpkgs/stable/#sec-language-go) which will import your existing dependency file, but you will need to [update the hash][nix-expression-hashes]:
+
+```go
+{ buildGoModule }:
+
+buildGoModule {
+  pname = "myproject";
+  version = "0.1.0";
+  src = ../../../.;
+
+  vendorHash = "<YOUR_HASH>";
+}
+```
+
 [build-concept]: ../../concepts/builds.md
 [pure-builds-section]: ../../concepts/manifest-builds.md#pure-builds
+[nix-expression-hashes]: ../../concepts/nix-expression-builds.md#generating-hashes

--- a/docs/cookbook/languages/jvm.md
+++ b/docs/cookbook/languages/jvm.md
@@ -10,6 +10,8 @@ description: Common questions and solutions for using the JVM ecosystem with Flo
 Not only can you _develop_ your software with Flox, but you can _build_ it as well.
 See the [builds][build-concept] concept page for more details.
 
+### Manifest builds
+
 This example will use [Gradle][gradle] and the [shadowJar][shadow] plugin, though a number of build systems exist in the Java ecosystem.
 The core of building a Java artifact with Flox looks like this:
 

--- a/docs/cookbook/languages/nodejs.md
+++ b/docs/cookbook/languages/nodejs.md
@@ -10,7 +10,9 @@ description: Common questions and solutions for using Node.js with Flox
 Not only can you _develop_ your software with Flox, but you can _build_ it as well.
 See the [builds][build-concept] concept page for more details.
 
-### npm
+### Manifest builds
+
+#### npm
 
 Building Node.js packages with `npm` looks similar to building for containers or serverless functions.
 On a high level, builds for Node.js-based projects generally follow this pattern:
@@ -48,7 +50,7 @@ chmod 755 $out/bin/myproject
 
 2. If your `npm build` already produces a binary that can be executed drectly, you can also copy or link that to `$out/bin`. Note that only binaries in `$out/bin` are wrapped to ensure they run within a consistent environment.
 
-### Vendoring dependencies in pure builds
+#### Vendoring dependencies in pure builds
 
 As discussed in the [pure builds][pure-builds-section] of the Builds concept page, pure builds run in a sandbox without network access on Linux.
 A pure build can be run as a multi-stage build where the first step vendors dependencies.
@@ -70,6 +72,29 @@ command = '''
   # The rest of the build is the same
 '''
 sandbox = "pure"
+```
+
+### Nix expression builds
+
+To build a project using [`buildNpmPackage`](https://nixos.org/manual/nixpkgs/stable/#language-javascript) which will import your existing dependency file:
+
+```nix
+{
+  buildNpmPackage,
+  importNpmLock,
+}:
+
+buildNpmPackage (final: {
+  pname = "myproject";
+  version = "0.1.0";
+  src = ../../../.;
+
+  npmDeps = importNpmLock {
+    npmRoot = final.src;
+  };
+  npmConfigHook = importNpmLock.npmConfigHook;
+  npmBuildScript = "build";
+});
 ```
 
 [build-concept]: ../../concepts/builds.md

--- a/docs/cookbook/languages/python.md
+++ b/docs/cookbook/languages/python.md
@@ -293,7 +293,9 @@ At this point, the version of `eralchemy` is available within your environment.
 Not only can you _develop_ your software with Flox, but you can _build_ it as well.
 See the [builds][build-concept] concept page for more details.
 
-### Pip
+### Manifest builds
+
+#### Pip
 
 For Python projects using `pip`, a build looks like installing the project to the `$out` directory.
 
@@ -309,7 +311,7 @@ current directory.
 If you're working in a repository with multiple packages in subdirectories,
 you would replace `.` with the path to the package sources.
 
-### Poetry
+#### Poetry
 
 For Poetry and tools that create a virtual environment for you, a build entails installing the virtual environment to `$out`.
 Poetry in particular does not allow you to choose the location (or name) of the virtual environment directory itself, but it does allow you to configure the _parent_ directory of the virtual environment.

--- a/docs/cookbook/languages/ruby.md
+++ b/docs/cookbook/languages/ruby.md
@@ -10,6 +10,8 @@ description: Common questions and solutions for using Ruby with Flox
 Not only can you _develop_ your software with Flox, but you can _build_ it as well.
 See the [builds][build-concept] concept page for more details.
 
+### Manifest builds
+
 Since Ruby is not a compiled language, to create an executable artifact you must create a shell script that calls `bundle exec`. Configure bundler to use the local directory to store the bundles by setting `$GEM_HOME` to something like `./vendor`. If you're Gemfile compiles native extensions, you may also want to `unset CPATH`. See the [Flox ruby environment](https://hub.flox.dev/flox/ruby) for more information, examples and specific details.
 
 For example, say you have an application whose source is in `app.rb`, and that you created a script called `myproject` at the root of your repository with the following contents:
@@ -39,7 +41,7 @@ command = '''
 '''
 ```
 
-### Vendoring dependencies in pure builds
+#### Vendoring dependencies in pure builds
 
 As discussed in the [pure builds][pure-builds-section] of the Builds concept page, pure builds run in a sandbox without network access on Linux.
 A pure build can be run as a multi-stage build where the first step vendors dependencies.

--- a/docs/cookbook/languages/rust.md
+++ b/docs/cookbook/languages/rust.md
@@ -183,6 +183,8 @@ It includes a GitHub Action that runs daily to keep up to date with the latest R
 Not only can you _develop_ your software with Flox, but you can _build_ it as well.
 See the [builds][build-concept] concept page for more details.
 
+### Manifest builds
+
 Since the output of the build must be copied to the `$out` directory, you'll need to copy the compiled executable out of the `target` directory and into `$out`.
 There is an unstable environment variable in Cargo that will allow you to set the output directory of the build, but we'll stick to stable features here:
 
@@ -195,7 +197,7 @@ command = '''
 '''
 ```
 
-### macOS builds require libiconv
+#### macOS builds require libiconv
 
 Rust executables built for macOS link against the `libiconv` library, which is used for some Unicode operations.
 This library is provided by macOS, and the large majority of Rust packages on macOS link against this library already, so this is not a dependency introduced by building via Flox.
@@ -208,7 +210,7 @@ libiconv.pkg-path = "libiconv"
 libiconv.systems = ["aarch64-darwin", "x86_64-darwin"]
 ```
 
-### Linux builds require GCC
+#### Linux builds require GCC
 
 On Linux, Rust executables link against `libgcc` for stack unwinding.
 `libgcc` is provided as part of the `gcc` package, which means that `gcc` needs to be available to your package at runtime on Linux.
@@ -230,7 +232,7 @@ runtime-packages = [… "gcc"]
 !!! note "Note"
     Depending on the `gcc` package at runtime includes `libgcc`, the compiler, its manpages, etc when in reality the package only depends on `libgcc` at runtime on Linux. This limitation will be addressed in the future.
 
-### Vendoring dependencies in pure builds
+#### Vendoring dependencies in pure builds
 
 As discussed in the [pure builds][pure-builds-section] of the Builds concept page, pure builds run in a sandbox without network access on Linux.
 A pure build can be run as a multi-stage build where the first step vendors dependencies.
@@ -263,6 +265,24 @@ EOF
 '''
 sandbox = "pure"
 runtime-packages = ["libiconv", "gcc"]
+```
+
+### Nix expression builds
+
+To build a project using [`buildRustPackage`](https://nixos.org/manual/nixpkgs/stable/#rust) which will import your existing dependency file:
+
+```nix
+{ rustPlatform }:
+
+rustPlatform.buildRustPackage {
+  pname = "myproject";
+  version = "0.0.1";
+  src = ../../../.;
+
+  cargoLock = {
+    lockFile = src + "/Cargo.lock";
+  };
+}
 ```
 
 [example_env]: https://github.com/flox/floxenvs/tree/main/rust


### PR DESCRIPTION
Add examples for all of the languages that we currently have in:

- https://github.com/flox/flox-build-examples

This required nesting the existing manifest build content under a new higher-level heading to make way for Nix expression build content in parallel.

I don't love how long this has made some of the pages, how hard it is to find a complete example to get going, and how likely we are to keep the examples up-to-date when they're not tested. I'd prefer to link out to the other repo rather than duplicate the content here but "the team" have a preference to keep the long form content here.

I also considered tabbing the content so that you can compare impure manifest builds, pure manifest builds, and Nix expression builds in one place, but it doesn't fit well with the narrative grouped content that we have currently.