### PR TITLE
docs(default): Remove --set-bool

### DIFF
--- a/docs/tutorials/default-environment.md
+++ b/docs/tutorials/default-environment.md
@@ -151,13 +151,13 @@ You can configure that with a single command:
 === "Do show the Flox prompt"
 
     ```bash
-    $ flox config --set-bool hide_default_prompt false
+    $ flox config --set hide_default_prompt false
     ```
 
 === "Don't show the Flox prompt"
 
     ```bash
-    $ flox config --set-bool hide_default_prompt true
+    $ flox config --set hide_default_prompt true
     ```
 
 ---


### PR DESCRIPTION
These args give a deprecation warning:

    ~/projects/flox/flox on HEAD (6fdd3617) [$]
    % flox config --set-bool hide_default_prompt false
    ⚠️  '--set-bool' is deprecated. Please use --set in the future instead.

    ~/projects/flox/flox on HEAD (6fdd3617) [$]
    % flox config --set hide_default_prompt true

    ~/projects/flox/flox on HEAD (6fdd3617) [$]
    %