### PR TITLE
Switch from 'flox services start mkdocs' to 'mkdocs serve'

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@ Live at: [flox.dev/docs](https://flox.dev/docs).
 $ flox activate
 ✅ You are now using the environment 'floxdocs'.
 
-λ (floxdocs) $ flox services start mkdocs
-✅ Service 'mkdocs' started.
-
+λ (floxdocs) $ mkdocs serve
+INFO    -  Building documentation...
+...
+INFO    -  [10:16:01] Serving on http://127.0.0.1:8000/docs/
 ```
 Once mkdocs service started you can preview the documentation at
-`https://127.0.0.1:8000`.
+`http://127.0.0.1:8000`.
 
 
 ## Guidelines
@@ -90,4 +91,3 @@ $ ./env/bin/pip install --upgrade build twine
 $ ./env/bin/python -m build
 $ cp dist/mkdocs_material-*.tar.gz path/to/floxdocs
 ```
-


### PR DESCRIPTION
Following the instructions in the README, I got an error when trying to preview the docs using `flox services start mkdocs`.

```
% flox services logs mkdocs
❌ ERROR: Services not started or quit unexpectedly.

To start services, run 'flox services start' in an activated environment,
or activate the environment with 'flox activate --start-services'.
```

When you activate the environment, it tells you to run `mkdocs serve` to preview the docs, and that works, so this PR updates the README to match.