### PR TITLE
chore: Create directory in command blob

### DIFF
--- a/docs/concepts/nix-expression-builds.md
+++ b/docs/concepts/nix-expression-builds.md
@@ -197,6 +197,7 @@ diff -ru hello-2.12.2/tests/hello-1 hello-patched/tests/hello-1
 Typically you would only override specific attributes of an existing package, which allows you to continue benefiting from upstream changes and surface failures if there are any conflicts, but if you want to copy a package to make more fundamental changes or because it's being removed upstream:
 
 ```{ .sh .copy }
+mkdir -p .flox/pkgs
 EDITOR=cat \
   nix --extra-experimental-features "nix-command flakes" \
   edit 'nixpkgs#hello' \


### PR DESCRIPTION
Prior to this change, if you ran the recommnded command to import a package
from nixpkgs, it could fail if you hadn't already made a `.flox/pkgs`
directory. This command now just does that, and if you have it, it's a noop.