### PR TITLE
Clean up FloxHub concept doc and improve cross-linking with Organizations

### DIFF
--- a/docs/concepts/floxhub.md
+++ b/docs/concepts/floxhub.md
@@ -18,6 +18,9 @@ you will be prompted to create an account.
 You can return to FloxHub to view your environments any time at
 [hub.flox.dev](https://hub.flox.dev).
 
+!!! note "Note"
+    If you need to share environments with a team, you can create an [Organization][organizations_concept] and push environments there instead of your personal account.
+
 ### Authenticating with the CLI
 
 You can authenticate with FloxHub from the Flox CLI.
@@ -52,11 +55,10 @@ the Environment Detail page.
 The FloxHub Environment Detail page lets you verify the contents of your
 environment and view its history in FloxHub.
 
-* **Sidebar**: shows key facts about the environment's current generation, like
-the number of packages, the systems supported, the active generation, and the
-last modified date.
+* **Sidebar**: shows key facts about the environment's live generation, like
+the systems supported and the last modified date.
 Below the key facts is a shortcut to the CLI sharing commands.
-* **Current generation tab**: shows you packages that are in your
+* **Details tab**: shows you packages that are in your
 [environment's manifest][manifest_concept].
 If your package was installed with a semantic version requirement,
 that information will show on the right side.
@@ -107,3 +109,4 @@ Run the [`flox auth logout`][flox_auth] command.
 [generation_concept]: ../concepts/generations.md
 [manifest_concept]: ../concepts/environments.md#manifesttoml
 [environments_concept]: ../concepts/environments.md
+[organizations_concept]: ../concepts/organizations.md

--- a/docs/concepts/generations.md
+++ b/docs/concepts/generations.md
@@ -8,7 +8,7 @@ description: Everything you need to know about generations.
 Generations refer to a **version number of an environment** on
 [FloxHub][floxhub_concept].
 Both imperative and declarative commands that modify an environment on
-[FloxHub][floxhub_concept] increment the generation number for the environment.
+FloxHub increment the generation number for the environment.
 
 Read more about creating your first generation in the
 [sharing guide][sharing_guide].
@@ -34,7 +34,7 @@ Suppose you [`flox pull`][flox_pull] an environment at generation 15 on
 If you now run [`flox install`][flox_install] three times then you will have
 generations 16-18 locally.
 The next [`flox push`][flox_push] would sync these three new generations to
-[FloxHub][floxhub_concept] if you have permission to write to the environment.
+FloxHub if you have permission to write to the environment.
 
 ## Switching and viewing generations
 
@@ -58,7 +58,7 @@ Rolling back to a previous generation introduces another concept:
 history.
 Rolling back doesn't create a new generation, but it does add an entry to the environment's history.
 Suppose you `flox generations rollback` from generation 18 to 17.
-Although the list of generations hasn't changed, the latest entry in the environment's history will now say that generation 17 is the current generation.
+Although the list of generations hasn't changed, the latest entry in the environment's history will now say that generation 17 is the live generation.
 Note that although generation 18 is the "latest" in the sense that it has the
 highest generation number and was most recently created, it is not the latest to
 be current.

--- a/docs/concepts/organizations.md
+++ b/docs/concepts/organizations.md
@@ -2,7 +2,7 @@
 
 --8<-- "paid-feature.md"
 
-An **organization** in FloxHub represents a shared workspace for teams. It provides:
+An **organization** in [FloxHub][floxhub_concept] represents a shared workspace for teams. It provides:
 
 - A private catalog
 - Scoped access control
@@ -48,7 +48,7 @@ Organizations in FloxHub include a view of all environments and packages owned b
 
 For each environment, users can:
 
-- See the current generation and a history of changes
+- See the live generation and a history of changes
 - Configure basic settings, such as owner and name
 - Delete environments
 
@@ -57,3 +57,5 @@ For each package, users can:
 - See package details, including supported systems and available versions
 
 Environments and packages created within an organization are visible to all its members, with access governed by the organization’s RBAC configuration.
+
+[floxhub_concept]: ./floxhub.md


### PR DESCRIPTION
* Some UI elements have changed ("live generations" and the name of the "Current Generation" tab)
* Adds a note in the FloxHub concept doc that if you need to share environments with a team, you should use an Organization instead of the personal account we create for you.
* Eliminates a few links to the FloxHub concepts docs when it's done a bit too aggressively (e.g. multiple times in the same paragraph).