### PR TITLE
fix(k8s): Fix comments about container image

### DIFF
--- a/docs/k8s/intro.md
+++ b/docs/k8s/intro.md
@@ -43,12 +43,9 @@ spec:
   # Required: directs containerd to use the Flox backend
   runtimeClassName: flox
   containers:
-    # The following container is not used but is required by the
-    # Kubernetes pod specification. Any valid values can be used here,
-    # but we provide the `flox/empty` container as a demonstration of
-    # the fact that the Flox environment relies on nothing from the
-    # container image.
-    - name: empty
+    - name: echoip
+      # We provide `flox/empty` as a demonstration that the Flox
+      # environment requires nothing from the container image.
       image: flox/empty:1.0.0
       # The command to run inside your environment
       command: ["echoip"]


### PR DESCRIPTION
It's not correct to say that the container image is "not used" because it gets unpacked as the rootfs that we make changes to.

Given this spec:

```
      containers:
        - name: hello-empty
          image: flox/empty:1.0.0
          command: ["sleep", "infinity"]
        - name: hello-alpine
          image: alpine:3
          command: ["sleep", "infinity"]
```

One uses Alpine as the base and the other doesn't:

```
% kc exec deploy/hello -c hello-alpine -- cat /etc/alpine-release
3.22.2
% kc exec deploy/hello -c hello-empty -- cat /etc/alpine-release
cat: /etc/alpine-release: No such file or directory
```

Created this ticket if we later want to implement it as a feature:

- https://github.com/flox/containerd-shim-flox/issues/41

I've also renamed the container from "empty" to "echoip" to indicate what it contains and is doing.