### PR TITLE
docs(k8s): Wrap flox auth token command

### DIFF
--- a/docs/k8s/config.md
+++ b/docs/k8s/config.md
@@ -18,7 +18,9 @@ To do so, you need to first login to FloxHub using the Flox CLI using [`flox aut
 You then create a new Kubernetes secret:
 
 ```bash
-flox auth token | kubectl create secret generic floxhub-token --from-file=floxhub-token=/dev/stdin
+flox auth token \
+  | kubectl create secret generic floxhub-token \
+    --from-file=floxhub-token=/dev/stdin
 ```
 
 !!! note "Flox CLI version"


### PR DESCRIPTION
So that it doesn't horizontally scroll and is easier to read.