### PR TITLE
docs: updates to generations since dropping remote

### DIFF
--- a/docs/concepts/floxhub.md
+++ b/docs/concepts/floxhub.md
@@ -65,7 +65,7 @@ that information will show on the right side.
 * **Generation tab**: shows you the history of your environment through each
 [generation][generation_concept].
 Each new [`flox push`][flox_push] creates a new generation.
-* **Change log tab**: describes the updates between each generation.
+* **History tab**: describes the updates between each generation.
 Packages that were installed with [`flox install`][flox_install] and uninstalled
 with [`flox uninstall`][flox_uninstall] will be explicitly marked.
 Packages that were added manually in a text editor or with

--- a/docs/concepts/generations.md
+++ b/docs/concepts/generations.md
@@ -65,7 +65,7 @@ highest generation number and was most recently created, it is not the latest to
 be live.
 
 This history of what generation is live at a given point in time can be
-viewed on FloxHub on the `Change Log` tab for an environment.
+viewed on FloxHub on the `History` tab for an environment.
 Or, to use the CLI to view history, you can run `flox generations history`.
 This provides a log of what generation of an environment was live at the time
 an environment was pulled.


### PR DESCRIPTION
- **docs: updates to generations since dropping remote**
  

- **docs: current -> live**
  We stopped using current a while ago but never updated the docs
  

- **docs: Change Log -> History**
  We've renamed the `Change Log` tab on FloxHub to `History`
  