### PR TITLE
chore: update tailscale/github-action from v3 to v4

### DIFF
--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -30,7 +30,7 @@ runs:
   using: "composite"
   steps:
     - name: "Setup Tailscale"
-      uses: "tailscale/github-action@v3"
+      uses: "tailscale/github-action@v4"
       if: ${{ inputs.TAILSCALE_AUTH_KEY }}
       with:
         oauth-secret: "${{ inputs.TAILSCALE_AUTH_KEY }}"


### PR DESCRIPTION
## Summary
Updates the Tailscale GitHub Action from v3 to v4.

## Changes
- Bump `tailscale/github-action` from v3 to v4 in common-setup action