### PR TITLE
feat: replace usage of `activate --` with `-c`

### DIFF
--- a/docs/concepts/activation.md
+++ b/docs/concepts/activation.md
@@ -12,7 +12,7 @@ _and_ all of your customizations.
 Given that environments are such an important part of Flox,
 it stands to reason that _how you use them_ is also an important part of Flox.
 
-There are three different ways to use an environment,
+There are four different ways to use an environment,
 and two different modes that an environment can be activated in.
 At the end of the day, though, it all boils down to properly configuring a
 shell.
@@ -51,9 +51,9 @@ Flox will place `<path to myenv>/.flox/run/<your system>.myenv.dev/bin` at the
 beginning of your `PATH` variable so that `hello` will be selected from your
 environment rather than from elsewhere on your system.
 
-## Three different ways to activate
+## Four different ways to activate
 
-We mentioned above that there are three different ways to use an environment.
+We mentioned above that there are four different ways to use an environment.
 
 ### Subshell
 
@@ -112,7 +112,7 @@ You could do this manually, but Flox will also prompt you to do it for you
 the first time you attempt to install a package in a directory without an
 environment and with no environments currently active.
 
-### Command
+### Shell Command
 
 Sometimes you just want to run a command in the context of your environment,
 maybe because you have some tools available in your environment that aren't
@@ -138,7 +138,7 @@ which you may not want.
 The easy way to do this is:
 
 ```{ .bash .copy }
-flox activate -- <your command>
+flox activate -c "<your command>"
 ```
 
 This starts a Flox-configured subshell, runs your command,
@@ -148,11 +148,30 @@ and immediately exits to put you back into your shell.
 shape: sequence_diagram
 user_shell: User shell
 subshell: Subshell
-user_shell -> subshell: "flox activate -- cmd"
+user_shell -> subshell: "flox activate -c cmd"
 subshell -> subshell: run "cmd"
 subshell -> user_shell: automatic exit
 user_shell."Back to you"
 ```
+
+### Exec Command
+
+The final way to activate an environment is to exec a command directly without an intermediate shell, which can be done with:
+
+```{ .bash .copy }
+flox activate -- <your command>
+```
+
+This is similar to `activate -c` in that it activates the environment, runs a
+command, and then exits.
+
+Unlike `-c`, when exec'ing a command directly with `--`:
+
+1. `[profile]` scripts aren't run
+1. Shell syntax isn't supported, so it's not possible to chain commands (e.g. `cmd1 && cmd2`), use shell builtins, or use aliases.
+
+When none of those features are needed, using `--` is faster than `-c` since
+there's no intermediate shell.
 
 ## Activation flow
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -31,8 +31,8 @@ flox install -d backend go sqlite
 flox install -d frontend nodejs
 
 # Activate and run commands in specific environments
-flox activate -d backend -- sh -c "cd backend && go mod init"
-flox activate -d frontend -- sh -c "cd frontend && npm install"
+flox activate -d backend -c "cd backend && go mod init"
+flox activate -d frontend -c "cd frontend && npm install"
 ```
 
 ## The Manifest

--- a/docs/tutorials/ci-cd.md
+++ b/docs/tutorials/ci-cd.md
@@ -17,7 +17,7 @@ For the following examples assume that you have a repository that contains a Flo
 
 Flox provides two different actions that you can use in a GitHub Actions workflow:
 
-- `flox/install-flox-action`: This action installs the Flox CLI so you can run Flox commands as you would locally. At some point you would typically run `flox activate -- <your command>` with this action to run a command inside the Flox environment.
+- `flox/install-flox-action`: This action installs the Flox CLI so you can run Flox commands as you would locally. At some point you would typically run `flox activate -c "<your command>"` with this action to run a command inside the Flox environment.
 - `flox/activate-action`: This action allows you to skip activating the environment yourself and simply provide the command that you would like to run in the environment.
 
 Note that the `flox/install-flox-action` is still required if you want to use `flox/activate-action`.
@@ -85,7 +85,7 @@ jobs:
 
 To run Flox in a GitLab pipeline you use a container image with Flox preinstalled.
 Flox provides the `ghcr.io/flox/flox` image for you to use in your pipelines.
-Inside the container you have access to the full Flox CLI, so running a command in the container looks the same as it would locally: `flox activate -- <your command>`.
+Inside the container you have access to the full Flox CLI, so running a command in the container looks the same as it would locally: `flox activate -c "<your command>"`.
 
 Here is an example GitLab pipeline that uses a Flox container to run `npm run build` inside the environment:
 
@@ -94,7 +94,7 @@ build:
   stage: build
   image: ghcr.io/flox/flox:latest # (1)!
   script:
-    - flox activate -- npm run build # (2)!
+    - flox activate -c "npm run build" # (2)!
 ```
 
 1. Use the `ghcr.io/flox/flox` container image, which comes with Flox already installed.


### PR DESCRIPTION
Current behavior of `--` is being replaced by `-c`, and `--` now execs a command directly without an intermediate shell.

I left some instances of `flox activate --` where it makes sense to exec a command directly. I considered recommending `-c` throughout to make things simpler for users, but then I think `--` will end up being too hard to find.