### PR TITLE
feat(llms): add AI agent integration section and ide-extensions link

### DIFF
--- a/docs/install-flox/ide-extensions.md
+++ b/docs/install-flox/ide-extensions.md
@@ -65,34 +65,54 @@ description: IDE extensions and AI agent integrations for Flox
     [cursor]: https://cursor.com
     [repo]: https://github.com/flox/flox-vscode
 
-=== "MCP and Skills"
+=== "Skills and MCP"
 
-    [Flox Agentic][agentic] is an MCP server and skill library that
-    gives AI coding agents access to Flox environments.
+    [Flox Agentic][agentic] provides a skill library and MCP server
+    that give AI coding agents expert knowledge of Flox environments,
+    builds, services, containers, publishing, and CUDA.
 
-    ## Install the MCP server
+    **Skills included:** `flox-environments`, `flox-services`,
+    `flox-builds`, `flox-containers`, `flox-publish`,
+    `flox-sharing`, `flox-cuda`
+
+    ## Claude Code
+
+    The Flox plugin for Claude Code installs both the skill library
+    and MCP server in one step:
+
+    ```{ .sh .code-command .copy }
+    claude plugin marketplace add flox/flox-agentic
+    ```
+
+    ```{ .sh .code-command .copy }
+    claude plugin install flox@flox-agentic
+    ```
+
+    ## Other agents (skills.sh)
+
+    For Cursor, Copilot, Windsurf, Gemini, and 15+ other agents,
+    use [skills.sh][skillssh] — a third-party open agent skills
+    ecosystem:
+
+    ```{ .sh .code-command .copy }
+    npx skills add flox/flox-agentic
+    ```
+
+    !!! note "Third-party tool"
+        skills.sh is not maintained by Flox. It requires Node.js.
+        See [skills.sh][skillssh] for supported agents and docs.
+
+    ## MCP server
+
+    For agents that support the
+    [Model Context Protocol][mcp] directly, install the MCP server:
 
     ```{ .sh .code-command .copy }
     flox install flox/flox-mcp-server
     ```
 
-    ## Claude Code
-
-    Add the MCP server to your project:
-
-    ```{ .sh .code-command .copy }
-    claude mcp add flox -- flox-mcp
-    ```
-
-    Or add it user-wide:
-
-    ```{ .sh .code-command .copy }
-    claude mcp add --scope user flox -- flox-mcp
-    ```
-
-    ## Cursor
-
-    Add the following to `~/.cursor/mcp.json`:
+    Then point your client at the `flox-mcp` command using stdio
+    transport. For Cursor, add to `~/.cursor/mcp.json`:
 
     ```{ .json .copy }
     {
@@ -104,13 +124,6 @@ description: IDE extensions and AI agent integrations for Flox
     }
     ```
 
-    ## Other MCP clients
-
-    Any editor or agent that supports the
-    [Model Context Protocol][mcp] can use Flox Agentic.
-    Point your client at the `flox-mcp` command using stdio
-    transport.
-
     ## Learn more
 
     Full documentation and source code:
@@ -118,3 +131,4 @@ description: IDE extensions and AI agent integrations for Flox
 
     [agentic]: https://github.com/flox/flox-agentic
     [mcp]: https://modelcontextprotocol.io
+    [skillssh]: https://skills.sh

--- a/docs/install-flox/ide-extensions.md
+++ b/docs/install-flox/ide-extensions.md
@@ -5,66 +5,6 @@ description: IDE extensions and AI agent integrations for Flox
 
 # Extensions
 
-=== "VS Code"
-
-    The [Flox extension for VS Code][marketplace] brings full
-    environment management into VS Code and compatible editors
-    like [Cursor][cursor].
-
-    ## Install from the Marketplace
-
-    !!! note "Requirements"
-        - Flox CLI installed ([install instructions](install.md))
-        - VS Code 1.87.0 or later
-
-    1. Open the Extensions view (++cmd+shift+x++ on macOS,
-       ++ctrl+shift+x++ on Linux)
-    2. Search for **Flox**
-    3. Click **Install**
-
-    ## Build and install from source
-
-    If you prefer to install manually, you can build a `.vsix` file
-    from the source repository:
-
-    1. Clone the repository and check out a release tag:
-
-        ```{ .sh .code-command .copy }
-        git clone https://github.com/flox/flox-vscode.git
-        cd flox-vscode
-        git checkout v1.0.1
-        ```
-
-    2. Activate the Flox environment and build the package:
-
-        ```{ .sh .code-command .copy }
-        flox activate
-        npm run package
-        ```
-
-        This creates a `.vsix` file in the project directory.
-
-    3. Install the `.vsix` file using the Command Palette
-       (++cmd+shift+p++ on macOS, ++ctrl+shift+p++ on Linux):
-
-        - Run **Extensions: Install from VSIX...**
-        - Select the generated `.vsix` file
-
-        Or install from the command line:
-
-        ```{ .sh .code-command .copy }
-        code --install-extension flox-*.vsix
-        ```
-
-    ## Source code
-
-    The extension is open source:
-    [github.com/flox/flox-vscode][repo]
-
-    [marketplace]: https://marketplace.visualstudio.com/items?itemName=flox.flox
-    [cursor]: https://cursor.com
-    [repo]: https://github.com/flox/flox-vscode
-
 === "Skills and MCP"
 
     [Flox Agentic][agentic] provides a skill library and MCP server
@@ -132,3 +72,63 @@ description: IDE extensions and AI agent integrations for Flox
     [agentic]: https://github.com/flox/flox-agentic
     [mcp]: https://modelcontextprotocol.io
     [skillssh]: https://skills.sh
+
+=== "VS Code"
+
+    The [Flox extension for VS Code][marketplace] brings full
+    environment management into VS Code and compatible editors
+    like [Cursor][cursor].
+
+    ## Install from the Marketplace
+
+    !!! note "Requirements"
+        - Flox CLI installed ([install instructions](install.md))
+        - VS Code 1.87.0 or later
+
+    1. Open the Extensions view (++cmd+shift+x++ on macOS,
+       ++ctrl+shift+x++ on Linux)
+    2. Search for **Flox**
+    3. Click **Install**
+
+    ## Build and install from source
+
+    If you prefer to install manually, you can build a `.vsix` file
+    from the source repository:
+
+    1. Clone the repository and check out a release tag:
+
+        ```{ .sh .code-command .copy }
+        git clone https://github.com/flox/flox-vscode.git
+        cd flox-vscode
+        git checkout v1.0.1
+        ```
+
+    2. Activate the Flox environment and build the package:
+
+        ```{ .sh .code-command .copy }
+        flox activate
+        npm run package
+        ```
+
+        This creates a `.vsix` file in the project directory.
+
+    3. Install the `.vsix` file using the Command Palette
+       (++cmd+shift+p++ on macOS, ++ctrl+shift+p++ on Linux):
+
+        - Run **Extensions: Install from VSIX...**
+        - Select the generated `.vsix` file
+
+        Or install from the command line:
+
+        ```{ .sh .code-command .copy }
+        code --install-extension flox-*.vsix
+        ```
+
+    ## Source code
+
+    The extension is open source:
+    [github.com/flox/flox-vscode][repo]
+
+    [marketplace]: https://marketplace.visualstudio.com/items?itemName=flox.flox
+    [cursor]: https://cursor.com
+    [repo]: https://github.com/flox/flox-vscode

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -24,6 +24,29 @@ sudo rpm -ivh /path/to/flox.rpm
 flox --version
 ```
 
+## AI Agent Integration
+
+Flox has a native MCP server and skill library for AI coding agents.
+
+```bash
+# Install the MCP server
+flox install flox/flox-mcp-server
+
+# Add to Claude Code (project-level)
+claude mcp add flox -- flox-mcp
+
+# Add to Claude Code (user-wide)
+claude mcp add --scope user flox -- flox-mcp
+```
+
+For Cursor, add to `~/.cursor/mcp.json`:
+```json
+{ "mcpServers": { "flox": { "command": "flox-mcp" } } }
+```
+
+Any MCP-compatible editor or agent can use Flox Agentic via stdio transport.
+Full details: https://flox.dev/docs/install-flox/ide-extensions/
+
 ## Essential Commands
 ```bash
 flox envs                        # See which environments are active

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -26,25 +26,28 @@ flox --version
 
 ## AI Agent Integration
 
-Flox has a native MCP server and skill library for AI coding agents.
+Flox Agentic provides skills and an MCP server for AI coding agents.
+Skills cover: environments, services, builds, containers, publishing,
+sharing, and CUDA.
 
+**Claude Code** (skills + MCP in one step):
 ```bash
-# Install the MCP server
+claude plugin marketplace add flox/flox-agentic
+claude plugin install flox@flox-agentic
+```
+
+**Other agents** (Cursor, Copilot, Windsurf, Gemini, 15+ more)
+via skills.sh (third-party, requires Node.js):
+```bash
+npx skills add flox/flox-agentic
+```
+
+**MCP server only** (any MCP-compatible client):
+```bash
 flox install flox/flox-mcp-server
-
-# Add to Claude Code (project-level)
-claude mcp add flox -- flox-mcp
-
-# Add to Claude Code (user-wide)
-claude mcp add --scope user flox -- flox-mcp
+# stdio transport, command: flox-mcp
 ```
 
-For Cursor, add to `~/.cursor/mcp.json`:
-```json
-{ "mcpServers": { "flox": { "command": "flox-mcp" } } }
-```
-
-Any MCP-compatible editor or agent can use Flox Agentic via stdio transport.
 Full details: https://flox.dev/docs/install-flox/ide-extensions/
 
 ## Essential Commands

--- a/tools/generate_llms_txt.py
+++ b/tools/generate_llms_txt.py
@@ -221,6 +221,7 @@ CURATED_LINKS = [
     ("Getting Started", [
         ("Flox in 5 Minutes", "https://flox.dev/docs/flox-5-minutes/", "Quick start guide"),
         ("Install Flox", "https://flox.dev/docs/install-flox/install/", "Install via flox.dev/download"),
+        ("IDE Extensions & AI Agent Integration", "https://flox.dev/docs/install-flox/ide-extensions/", "MCP server, Claude Code, Cursor, VS Code"),
         ("What is Flox?", "https://flox.dev/docs/", "Overview"),
     ]),
     ("Core Concepts", [


### PR DESCRIPTION
Follow-up to #471.

## Changes

- **`docs/llms.txt`**: Add `## AI Agent Integration` section near the top
  with MCP server install instructions for Claude Code and Cursor.
  This is the most relevant content for AI agents reading this file
  and was completely absent before.

- **`tools/generate_llms_txt.py`**: Add "IDE Extensions & AI Agent
  Integration" to the curated Getting Started link list, pointing to
  `flox.dev/docs/install-flox/ide-extensions/`.

Closes AI-15
ref AI-13