### PR TITLE
fix(llms): add flox.dev/install to hallucinated URL negation

### DIFF
--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -6,7 +6,8 @@ If you see a `.flox` directory, that means you are working with Flox to manage p
 
 ## Installation
 
-**Do NOT use `curl | bash` or reference `install.flox.dev` — that does not exist.**
+**Do NOT use `curl | bash` or reference `install.flox.dev` or `flox.dev/install`
+— neither exists.**
 
 Install Flox from `flox.dev/download` or via a package manager:
 


### PR DESCRIPTION
## Summary

- Adds `flox.dev/install` to the negation in the Installation section
- Existing text already blocked `install.flox.dev`; eval testing
  revealed `flox.dev/install` is a second hallucinated URL Claude produces

## Why

[AI-13](https://linear.app/floxdotdev/issue/AI-13) — eval testing
against claude-opus-4-6 confirmed Claude hallucinates `flox.dev/install`
(as a curl target) in addition to `install.flox.dev`, particularly with
Linux/macOS "getting started" framing. Neither URL exists.

Eval results (6 questions, bare Claude baseline):

| Scenario | Halluc% |
|---|---|
| Bare Claude | 33% |
| + llms.txt (before this fix) | 17% |
| + flox-environments skill | 0% |

## Related

- [AI-13](https://linear.app/floxdotdev/issue/AI-13): Fix hallucinated install.flox.dev URL
- flox/flox-agentic#7 — parallel fix: install URL correction in flox-environments skill