### PR TITLE
docs(concepts): ECO-47 add catalog imports concept page

### DIFF
--- a/docs/concepts/catalog-imports.md
+++ b/docs/concepts/catalog-imports.md
@@ -43,7 +43,7 @@ version = 1
 
 [catalogs.my-packages]
 type = "git"
-url = "https://github.com/myorg/my-packages"
+url = "https://github.com/flox/flox-build-examples"
 ```
 
 As a shorthand, you can provide a single `url` field using Nix
@@ -53,7 +53,7 @@ source reference syntax (the `git+` prefix encodes the type):
 version = 1
 
 [catalogs.my-packages]
-url = "git+https://github.com/myorg/my-packages"
+url = "git+https://github.com/flox/flox-build-examples"
 ```
 
 You can also use TOML dotted key syntax under a `[catalogs]`
@@ -64,7 +64,7 @@ version = 1
 
 [catalogs]
 my-packages.type = "git"
-my-packages.url = "https://github.com/myorg/my-packages"
+my-packages.url = "https://github.com/flox/flox-build-examples"
 ```
 
 ### Optional fields

--- a/docs/concepts/catalog-imports.md
+++ b/docs/concepts/catalog-imports.md
@@ -1,0 +1,245 @@
+---
+title: "Catalog imports"
+description: Import packages from external catalogs for Nix expression builds
+---
+
+## Overview
+
+Catalog imports allow your Nix expression builds to depend on
+packages provided by external sources: remote Git repositories
+or FloxHub users and organizations that publish reusable packages.
+
+Rather than vendoring dependencies or using Nix flake inputs
+directly, you declare catalogs in a configuration file and
+access their packages via the `catalogs` argument in your
+expressions. This keeps your build inputs explicit, lockable,
+and reproducible.
+
+Catalog imports extend [Nix expression builds][nix-expression-builds].
+You should be familiar with defining packages in `.flox/pkgs/`
+before using catalog imports.
+
+## Configuring catalogs
+
+Catalog imports use a two-file system:
+
+- **`.flox/nix-builds.toml`** — the user-authored configuration
+  file where you declare which catalogs to use.
+- **`.flox/nix-builds.lock`** — a generated lockfile that pins
+  each catalog to a specific revision for reproducibility.
+
+Both files should be committed to version control. The TOML file
+is authored by hand; the lockfile is generated and updated by
+the `flox build update-catalogs` command.
+
+## Source-ref (Git) catalogs
+
+A Git catalog points at a remote repository that contains Flox
+package definitions (a `.flox/pkgs/` directory). Declare one in
+your `nix-builds.toml` under the `[catalogs]` section:
+
+```{ .toml .copy title=".flox/nix-builds.toml" }
+[catalogs.my-packages]
+type = "git"
+url = "git+https://github.com/myorg/my-packages"
+```
+
+You can also use the dotted key shorthand for simple cases:
+
+```{ .toml .copy title=".flox/nix-builds.toml" }
+my-packages.type = "git"
+my-packages.url = "git+https://github.com/myorg/my-packages"
+```
+
+### Optional fields
+
+| Field | Description |
+| ----- | ----------- |
+| `ref` | Git ref to track (branch, tag). Defaults to the repository's default branch. |
+| `dir` | Subdirectory containing the `.flox/pkgs/` tree. Useful for monorepos. |
+
+For example, to point at a subdirectory within a monorepo:
+
+```{ .toml .copy title=".flox/nix-builds.toml" }
+[catalogs.flox-demo]
+type = "git"
+url = "git+https://github.com/flox/flox-build-examples"
+dir = "quotes-app-rust"
+```
+
+## FloxHub catalogs
+
+A FloxHub catalog references packages published to FloxHub via
+[`flox publish`][publishing]. The catalog name corresponds to
+the FloxHub user or organization that published them.
+
+```{ .toml .copy title=".flox/nix-builds.toml" }
+[catalogs.ysndr]
+type = "floxhub"
+```
+
+Or with dotted key syntax:
+
+```{ .toml .copy title=".flox/nix-builds.toml" }
+ysndr.type = "floxhub"
+```
+
+Public catalogs work without authentication. Private catalogs
+(those published by an organization with restricted access)
+require you to authenticate first with `flox auth login`.
+
+## Using catalogs in expressions
+
+Once catalogs are declared in `nix-builds.toml` and the lockfile
+is generated, you access imported packages through the `catalogs`
+argument in your Nix expressions.
+
+!!! important
+    The argument name must be `catalogs` (plural). Using
+    `catalog` (singular) will not work.
+
+The access pattern is:
+
+```{ .nix .copy }
+catalogs.<catalog-name>.<package-name>
+```
+
+For example, an expression that uses a package from a catalog:
+
+```{ .nix .copy title=".flox/pkgs/demo.nix" }
+{ catalogs }:
+
+catalogs.flox-demo.quotes-app-rust-nix
+```
+
+The `catalogs` argument can be combined with other arguments
+from nixpkgs:
+
+```{ .nix .copy title=".flox/pkgs/my-app.nix" }
+{ catalogs, rustPlatform, lib }:
+
+rustPlatform.buildRustPackage {
+  pname = "my-app";
+  version = "0.1.0";
+  src = ../../.;
+  cargoLock.lockFile = ../../Cargo.lock;
+  buildInputs = [ catalogs.shared-libs.common-utils ];
+  meta.license = lib.licenses.mit;
+}
+```
+
+## Updating catalog locks
+
+Before you can build with catalog imports, you must generate the
+lockfile. Run:
+
+```{ .sh .copy }
+flox build update-catalogs
+```
+
+This resolves each catalog declaration in `nix-builds.toml` and
+writes the pinned revisions to `nix-builds.lock`.
+
+Re-run this command whenever you:
+
+- Add or change a catalog entry in `nix-builds.toml`
+- Want to pick up newer versions of packages from a catalog
+
+After updating, commit both `.flox/nix-builds.toml` and
+`.flox/nix-builds.lock` to version control.
+
+!!! note
+    If you run `flox build` without first generating or updating
+    the lockfile, the build will fail with an error indicating
+    that catalogs have not been resolved.
+
+## Examples
+
+### Example: Git catalog
+
+This example imports a Rust application from the
+[flox-build-examples](https://github.com/flox/flox-build-examples)
+repository.
+
+**1. Declare the catalog:**
+
+```{ .toml .copy title=".flox/nix-builds.toml" }
+[catalogs.flox-demo]
+type = "git"
+url = "git+https://github.com/flox/flox-build-examples"
+dir = "quotes-app-rust"
+```
+
+**2. Write an expression that uses it:**
+
+```{ .nix .copy title=".flox/pkgs/demo.nix" }
+{ catalogs }:
+
+catalogs.flox-demo.quotes-app-rust-nix
+```
+
+**3. Update the lockfile and build:**
+
+```{ .sh .copy }
+flox build update-catalogs
+flox build demo
+```
+
+### Example: FloxHub catalog
+
+This example uses a package published to FloxHub by the user
+`ysndr`.
+
+**1. Declare the catalog:**
+
+```{ .toml .copy title=".flox/nix-builds.toml" }
+ysndr.type = "floxhub"
+```
+
+**2. Write an expression that uses it:**
+
+```{ .nix .copy title=".flox/pkgs/demo.nix" }
+{ catalogs }:
+
+catalogs.ysndr.blub
+```
+
+**3. Update the lockfile and build:**
+
+```{ .sh .copy }
+flox build update-catalogs
+flox build demo
+```
+
+### Example: Combining catalogs with nixpkgs
+
+A realistic expression might use both catalog imports and
+standard nixpkgs helpers:
+
+```{ .nix .copy title=".flox/pkgs/my-tool.nix" }
+{ catalogs, rustPlatform, lib }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "my-tool";
+  version = "0.1.0";
+
+  src = ../../.;
+  cargoLock.lockFile = "${src}/Cargo.lock";
+
+  buildInputs = [
+    catalogs.shared-libs.crypto-utils
+  ];
+
+  meta = with lib; {
+    description = "A tool that uses shared crypto utilities";
+    license = licenses.mit;
+  };
+}
+```
+
+Here `rustPlatform` and `lib` come from nixpkgs (as with any
+standard Nix expression build), while `catalogs.shared-libs.crypto-utils`
+is resolved from the declared catalog.
+
+[nix-expression-builds]: ./nix-expression-builds.md
+[publishing]: ./publishing.md

--- a/docs/concepts/catalog-imports.md
+++ b/docs/concepts/catalog-imports.md
@@ -39,16 +39,32 @@ package definitions (a `.flox/pkgs/` directory). Declare one in
 your `nix-builds.toml` under the `[catalogs]` section:
 
 ```{ .toml .copy title=".flox/nix-builds.toml" }
+version = 1
+
 [catalogs.my-packages]
 type = "git"
+url = "https://github.com/myorg/my-packages"
+```
+
+As a shorthand, you can provide a single `url` field using Nix
+source reference syntax (the `git+` prefix encodes the type):
+
+```{ .toml .copy title=".flox/nix-builds.toml" }
+version = 1
+
+[catalogs.my-packages]
 url = "git+https://github.com/myorg/my-packages"
 ```
 
-You can also use the dotted key shorthand for simple cases:
+You can also use TOML dotted key syntax under a `[catalogs]`
+header for simple cases:
 
 ```{ .toml .copy title=".flox/nix-builds.toml" }
+version = 1
+
+[catalogs]
 my-packages.type = "git"
-my-packages.url = "git+https://github.com/myorg/my-packages"
+my-packages.url = "https://github.com/myorg/my-packages"
 ```
 
 ### Optional fields
@@ -61,9 +77,11 @@ my-packages.url = "git+https://github.com/myorg/my-packages"
 For example, to point at a subdirectory within a monorepo:
 
 ```{ .toml .copy title=".flox/nix-builds.toml" }
+version = 1
+
 [catalogs.flox-demo]
 type = "git"
-url = "git+https://github.com/flox/flox-build-examples"
+url = "https://github.com/flox/flox-build-examples"
 dir = "quotes-app-rust"
 ```
 
@@ -74,6 +92,8 @@ A FloxHub catalog references packages published to FloxHub via
 the FloxHub user or organization that published them.
 
 ```{ .toml .copy title=".flox/nix-builds.toml" }
+version = 1
+
 [catalogs.ysndr]
 type = "floxhub"
 ```
@@ -81,6 +101,9 @@ type = "floxhub"
 Or with dotted key syntax:
 
 ```{ .toml .copy title=".flox/nix-builds.toml" }
+version = 1
+
+[catalogs]
 ysndr.type = "floxhub"
 ```
 
@@ -164,9 +187,11 @@ repository.
 **1. Declare the catalog:**
 
 ```{ .toml .copy title=".flox/nix-builds.toml" }
+version = 1
+
 [catalogs.flox-demo]
 type = "git"
-url = "git+https://github.com/flox/flox-build-examples"
+url = "https://github.com/flox/flox-build-examples"
 dir = "quotes-app-rust"
 ```
 
@@ -193,6 +218,9 @@ This example uses a package published to FloxHub by the user
 **1. Declare the catalog:**
 
 ```{ .toml .copy title=".flox/nix-builds.toml" }
+version = 1
+
+[catalogs]
 ysndr.type = "floxhub"
 ```
 

--- a/docs/concepts/nix-expression-builds.md
+++ b/docs/concepts/nix-expression-builds.md
@@ -206,6 +206,17 @@ EDITOR=cat \
 
 This will extract the expression for the `hello` package in `nixpkgs` and save the contents to file which can then be modified.
 
+## Catalog imports
+
+Nix expression builds can depend on packages provided by external
+catalogs — remote repositories or FloxHub users that publish reusable
+packages. Rather than vendoring dependencies or using Nix flake inputs
+directly, you declare catalogs in `.flox/nix-builds.toml` and access
+their packages via the `catalogs` argument in your expressions.
+
+See [Catalog imports](./catalog-imports.md) for full documentation
+and examples.
+
 ## Tips
 
 ### Generating hashes

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,6 +85,7 @@ nav:
     - Builds: concepts/builds.md
     - Manifest builds: concepts/manifest-builds.md
     - Nix expression builds: concepts/nix-expression-builds.md
+    - Catalog imports: concepts/catalog-imports.md
     - Publishing: concepts/publishing.md
     - Secrets management: concepts/secrets-management.md
     - Flox vs. container workflows: concepts/flox-vs-containers.md


### PR DESCRIPTION
## Summary

- Create new concept page `docs/concepts/catalog-imports.md` covering catalog imports for Nix expression builds
- Add cross-reference section in `nix-expression-builds.md` pointing to the new page
- Add nav entry in `mkdocs.yml` between Nix expression builds and Publishing

## Details

The new page covers:
- Git catalogs (`type = "git"`) with URL, ref, and dir fields
- FloxHub catalogs (`type = "floxhub"`) for published packages
- The `catalogs` argument in Nix expressions
- Lockfile management via `flox build update-catalogs`
- Worked examples for Git, FloxHub, and combined catalog+nixpkgs usage

## Test plan

- [x] `mkdocs build --strict` passes without errors
- [ ] Visual review of rendered page

Fixes ECO-47