### PR TITLE
Remove leftover merge conflict markers

### DIFF
--- a/docs/flox-5-minutes.md
+++ b/docs/flox-5-minutes.md
@@ -135,11 +135,7 @@ The sample environment includes a simple `stopwatch` service. Start it up:
 
 ```{ .console }
 $ flox services start
-<<<<<<< HEAD
-✓ Service 'stopwatch' started.
-=======
 ✔ Service 'stopwatch' started.
->>>>>>> c597a6c (fix: use unicode rather than emoji)
 ```
 
 You can check on the status of services and tail their logs just like you would with any process manager:
@@ -166,11 +162,7 @@ Press `Ctrl-C` to stop watching the logs. When you're done, stop the service:
 
 ```{ .console }
 $ flox services stop
-<<<<<<< HEAD
-✓ Service 'stopwatch' stopped
-=======
 ✔ Service 'stopwatch' stopped
->>>>>>> c597a6c (fix: use unicode rather than emoji)
 ```
 
 Services are automatically stopped when you exit the environment, so you don't have to worry about orphaned processes.


### PR DESCRIPTION
Just a tiny docs fix

Before:
<img width="716" height="168" alt="Screenshot 2026-05-07 at 5 14 52 PM" src="https://github.com/user-attachments/assets/1663515c-be90-4c26-87c4-7b40dcb119c3" />

After:
<img width="1018" height="100" alt="Screenshot 2026-05-07 at 5 15 21 PM" src="https://github.com/user-attachments/assets/b0065a65-fd06-49dd-9395-e49af80d7842" />
