### PR TITLE
Redirect legacy docs.flox.dev to flox.dev/docs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,38 @@
+# This site (docs.flox.dev) is the legacy MkDocs docs.
+# It now redirects to the new Mintlify docs at flox.dev/docs.
+#
+# Netlify matches `from` paths trailing-slash-insensitively, so these
+# rules cover both `/path` and `/path/`. More specific rules must come
+# first (first match wins).
+
+# --- Pages renamed/removed in the migration: map to their closest home ---
+
+[[redirects]]
+  from = "/docs/man/flox-build-update-catalogs"
+  to = "https://flox.dev/docs/man/flox-build"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/docs/man/nix-builds.toml"
+  to = "https://flox.dev/docs/man/manifest.toml"
+  status = 301
+  force = true
+
+# --- Path-preserving redirect for everything else under /docs/ ---
+# 93 of 99 legacy URLs resolve 1:1 on the new site (the rest are former
+# MkDocs include/snippet partials that were never real pages).
+
+[[redirects]]
+  from = "/docs/*"
+  to = "https://flox.dev/docs/:splat"
+  status = 301
+  force = true
+
+# --- Anything outside /docs/ -> the new docs home ---
+
 [[redirects]]
   from = "/*"
-  to = "/docs/"
-  status = 302
-  force = false
+  to = "https://flox.dev/docs"
+  status = 301
+  force = true


### PR DESCRIPTION
## Problem

`docs.flox.dev` still serves the **old MkDocs docs** (this site, `floxdocs.netlify.app`). The new Mintlify docs live at `flox.dev/docs`. Per Tanja, we want a 301 so the legacy subdomain forwards to the new home.

## Change

Replaces the single `/* → /docs/` (302) rule with permanent (301) redirects to `flox.dev/docs`:

- **Path-preserving**: `/docs/* → https://flox.dev/docs/:splat`. I tested all 99 URLs from the old sitemap against the new site — **93 resolve 1:1** (the new site's legacy redirect rules + Mintlify handle them).
- **Explicit mappings** for 2 pages reorganized in the migration:
  - `/docs/man/flox-build-update-catalogs` → `/docs/man/flox-build`
  - `/docs/man/nix-builds.toml` → `/docs/man/manifest.toml`
- **Fallback**: everything else → `https://flox.dev/docs`.

The remaining 4 of the 99 are former MkDocs `include/`/`snippets/` partials that were never real pages, so no user-facing 404s.

## Verify after deploy

- [ ] `curl -I https://docs.flox.dev/` → 301 → `https://flox.dev/docs`
- [ ] `curl -I https://docs.flox.dev/docs/install-flox/install/` → 301 → `https://flox.dev/docs/install-flox/install` (200)
- [ ] `curl -I https://docs.flox.dev/docs/man/flox-build-update-catalogs/` → 301 → `/docs/man/flox-build`

Note: the `flox/flox` → `floxdocs` release sync only touches doc content, not `netlify.toml`, so this redirect should persist until FLO-53 retires this site.